### PR TITLE
Støtte for autorisering basert på custom roles for maskin til maskin kall

### DIFF
--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
@@ -70,3 +70,7 @@ fun ApplicationCall.azp(): AzpName {
     }
     return AzpName(azp)
 }
+
+fun ApplicationCall.rolesClaim(): List<String> {
+    return principal<JWTPrincipal>()?.getListClaim("roles", String::class) ?: emptyList()
+}

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
@@ -14,7 +14,6 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.RoutingNode
 import io.ktor.util.AttributeKey
-import no.nav.aap.komponenter.httpklient.auth.AzpName
 import no.nav.aap.komponenter.httpklient.auth.token
 import no.nav.aap.komponenter.json.DefaultJsonMapper
 import org.slf4j.LoggerFactory
@@ -61,14 +60,6 @@ inline fun buildTilgangPlugin(crossinline parse: suspend (call: ApplicationCall)
 suspend inline fun <reified T : Any> ApplicationCall.parseGeneric(): T {
     if (T::class == Unit::class) return Unit as T
     return DefaultJsonMapper.fromJson<T>(receiveText())
-}
-
-fun ApplicationCall.azp(): AzpName {
-    val azp = principal<JWTPrincipal>()?.getClaim("azp_name", String::class)
-    if (azp == null) {
-        error("azp mangler i AzureAD claims")
-    }
-    return AzpName(azp)
 }
 
 fun ApplicationCall.rolesClaim(): List<String> {

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangService.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangService.kt
@@ -13,8 +13,12 @@ object TilgangService {
         token: OidcToken
     ): Boolean {
         if (token.isClientCredentials()) {
-            val azpName = call.azp()
-            return authorizedRequest.approvedApplications.contains(azpName.name)
+            return if (authorizedRequest.applicationRole != null) {
+                call.rolesClaim().contains(authorizedRequest.applicationRole)
+            } else {
+                val azpName = call.azp()
+                authorizedRequest.approvedApplications?.contains(azpName.name) == true
+            }
         }
         if (authorizedRequest.applicationsOnly) {
             return false

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangService.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangService.kt
@@ -13,12 +13,8 @@ object TilgangService {
         token: OidcToken
     ): Boolean {
         if (token.isClientCredentials()) {
-            return if (authorizedRequest.applicationRole != null) {
-                call.rolesClaim().contains(authorizedRequest.applicationRole)
-            } else {
-                val azpName = call.azp()
-                authorizedRequest.approvedApplications?.contains(azpName.name) == true
-            }
+            return authorizedRequest.applicationRole != null &&
+                    call.rolesClaim().contains(authorizedRequest.applicationRole)
         }
         if (authorizedRequest.applicationsOnly) {
             return false

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -64,7 +64,7 @@ fun Application.autorisertEksempelApp() {
                         authorizedPost<Unit, Long, Journalpostinfo>(
                             AuthorizationBodyPathConfig(
                                 operasjon = Operasjon.SAKSBEHANDLE,
-                                approvedApplications = setOf("azp")
+                                applicationRole = "tilgang-rolle",
                             ),
                             modules = arrayOf(TagModule(listOf(Tags.Tilgangkontrollert)))
                         ) { _, dto ->
@@ -78,16 +78,6 @@ fun Application.autorisertEksempelApp() {
                     route("on-behalf-of") {
                         authorizedGet<TestReferanse, Saksinfo>(
                             AuthorizationParamPathConfig(sakPathParam = SakPathParam("saksnummer"))
-                        ) { req ->
-                            respond(Saksinfo(saksnummer = req.saksnummer))
-                        }
-                    }
-                    route("client-credentials-approved-applications") {
-                        authorizedGet<TestReferanse, Saksinfo>(
-                            AuthorizationParamPathConfig(
-                                approvedApplications = setOf("azp"),
-                                applicationsOnly = true
-                            )
                         ) { req ->
                             respond(Saksinfo(saksnummer = req.saksnummer))
                         }
@@ -106,7 +96,7 @@ fun Application.autorisertEksempelApp() {
                         authorizedGet<TestReferanse, Saksinfo>(
                             AuthorizationParamPathConfig(
                                 sakPathParam = SakPathParam("saksnummer"),
-                                approvedApplications = setOf("azp")
+                                applicationRole = "tilgang-rolle"
                             )
                         ) { req ->
                             respond(Saksinfo(saksnummer = req.saksnummer))
@@ -125,21 +115,10 @@ fun Application.autorisertEksempelApp() {
                         authorizedPost<Unit, Saksinfo, Saksinfo>(
                             AuthorizationBodyPathConfig(
                                 operasjon = Operasjon.SAKSBEHANDLE,
-                                approvedApplications = setOf("azp")
+                                applicationRole = "tilgang-rolle"
                             )
                         ) { _, dto ->
                             respond(Saksinfo(saksnummer = uuid))
-                        }
-                    }
-                    route("client-credentials-approved-applications") {
-                        authorizedPost<Unit, IngenReferanse, IngenReferanse>(
-                            AuthorizationBodyPathConfig(
-                                operasjon = Operasjon.SAKSBEHANDLE,
-                                approvedApplications = setOf("azp"),
-                                applicationsOnly = true
-                            )
-                        ) { _, dto ->
-                            respond(dto)
                         }
                     }
                     route("client-credentials-application-role") {

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -82,10 +82,20 @@ fun Application.autorisertEksempelApp() {
                             respond(Saksinfo(saksnummer = req.saksnummer))
                         }
                     }
-                    route("client-credentials") {
+                    route("client-credentials-approved-applications") {
                         authorizedGet<TestReferanse, Saksinfo>(
                             AuthorizationParamPathConfig(
                                 approvedApplications = setOf("azp"),
+                                applicationsOnly = true
+                            )
+                        ) { req ->
+                            respond(Saksinfo(saksnummer = req.saksnummer))
+                        }
+                    }
+                    route("client-credentials-application-role") {
+                        authorizedGet<TestReferanse, Saksinfo>(
+                            AuthorizationParamPathConfig(
+                                applicationRole = "tilgang-rolle",
                                 applicationsOnly = true
                             )
                         ) { req ->
@@ -121,11 +131,22 @@ fun Application.autorisertEksempelApp() {
                             respond(Saksinfo(saksnummer = uuid))
                         }
                     }
-                    route("client-credentials") {
+                    route("client-credentials-approved-applications") {
                         authorizedPost<Unit, IngenReferanse, IngenReferanse>(
                             AuthorizationBodyPathConfig(
                                 operasjon = Operasjon.SAKSBEHANDLE,
                                 approvedApplications = setOf("azp"),
+                                applicationsOnly = true
+                            )
+                        ) { _, dto ->
+                            respond(dto)
+                        }
+                    }
+                    route("client-credentials-application-role") {
+                        authorizedPost<Unit, IngenReferanse, IngenReferanse>(
+                            AuthorizationBodyPathConfig(
+                                operasjon = Operasjon.SAKSBEHANDLE,
+                                applicationRole = "tilgang-rolle",
                                 applicationsOnly = true
                             )
                         ) { _, dto ->


### PR DESCRIPTION
Autorisering basert på custom roles kan erstatte autorisering med approvedApplications som bruker azp_name.

Ref: https://docs.nais.io/auth/entra-id/reference/#custom-roles