### PR TITLE
AAP-1065 Hent barn fra PDL for adressebeskyttelseRegel

### DIFF
--- a/app/main/kotlin/tilgang/integrasjoner/pdl/PdlRequest.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/pdl/PdlRequest.kt
@@ -14,6 +14,10 @@ internal data class PdlRequest(val query: String, val variables: Variables) {
             query = GEOGRAFISK_TILKNYTNING_QUERY.asQuery(),
             variables = Variables(ident = ident)
         )
+        fun hentBarnForPerson(personidenter: List<String>) = PdlRequest(
+            query = BARN_RELASJON_QUERY.asQuery(),
+            variables = Variables(identer = personidenter),
+        )
     }
 }
 
@@ -43,4 +47,18 @@ val GEOGRAFISK_TILKNYTNING_QUERY = """
             gtLand
         }
 }
+""".trimIndent()
+
+val BARN_RELASJON_QUERY = """
+    query($identer: ID!) {
+        hentPersonBolk(identer: $identer) {
+            ident,
+            person {
+                forelderBarnRelasjon {
+                    relatertPersonsIdent
+                    relatertPersonsRolle
+                }
+            }
+        }
+    }
 """.trimIndent()

--- a/app/main/kotlin/tilgang/integrasjoner/pdl/PdlRespons.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/pdl/PdlRespons.kt
@@ -21,15 +21,21 @@ internal data class PdlData(
     val hentPersonBolk: List<HentPersonBolkResult>?
 )
 
-internal data class HentPersonBolkResult(
+data class HentPersonBolkResult(
     val ident: String,
     val person: PdlPerson?,
     val code: String,
 )
 
-internal data class PdlPerson(
+data class PdlPerson(
     val adressebeskyttelse: List<Adressebeskyttelse>?,
-    val code: Code?     //Denne er påkrevd ved hentPersonBolk
+    val code: Code?,     // Denne er påkrevd ved hentPersonBolk
+    val forelderBarnRelasjon: List<PdlForelderBarnRelasjon>?,
+)
+
+data class PdlForelderBarnRelasjon(
+    val relatertPersonsIdent: String,
+    val relatertPersonsRolle: PdlRelatertPersonsRolleType,
 )
 
 data class HentGeografiskTilknytningResult(
@@ -39,11 +45,15 @@ data class HentGeografiskTilknytningResult(
     val gtLand: String?
 )
 
+enum class PdlRelatertPersonsRolleType {
+    FAR, MOR, BARN, MEDMOR
+}
+
 enum class PdlGeoType {
     BYDEL, KOMMUNE, UDEFINERT, UTLAND
 }
 
-internal enum class Code {
+enum class Code {
     ok, not_found, bad_request //TODO: add more
 }
 
@@ -54,7 +64,7 @@ internal data class PdlVegadresse(
     val postnummer: String,
 )
 
-internal data class Adressebeskyttelse(
+data class Adressebeskyttelse(
     val gradering: Gradering
 )
 

--- a/app/main/kotlin/tilgang/integrasjoner/skjerming/SkjermingClient.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/skjerming/SkjermingClient.kt
@@ -38,6 +38,7 @@ open class SkjermingClient(
         prometheus.cacheMiss(SKJERMING_PREFIX).increment()
 
         val url = baseUrl.resolve("/skjermetBulk")
+        // TODO: Identer på barn må hentes fra PDL
         val alleRelaterteSøkerIdenter = (identer.søker + identer.barn).distinct()
 
         val response: Map<String, Boolean> =

--- a/app/main/kotlin/tilgang/regler/AdressebeskyttelseRegel.kt
+++ b/app/main/kotlin/tilgang/regler/AdressebeskyttelseRegel.kt
@@ -41,13 +41,14 @@ class AdressebeskyttelseInputGenerator(
 ) :
     InputGenerator<AdressebeskyttelseInput> {
     override fun generer(input: RegelInput): AdressebeskyttelseInput {
-        val personer = requireNotNull(
+        val søkerFraPdl = requireNotNull(
             pdlService.hentPersonBolk(
-                input.søkerIdenter.søker.union(input.søkerIdenter.barn).toList(),
+                input.søkerIdenter.søker,
                 input.callId
             )
         )
+        val barnFraPdl = pdlService.hentBarnForPerson(input.søkerIdenter.søker, input.callId) ?: emptyList()
         val roller = adressebeskyttelseService.hentAdressebeskyttelseRoller(input.currentToken, input.ansattIdent)
-        return AdressebeskyttelseInput(roller, personer)
+        return AdressebeskyttelseInput(roller, søkerFraPdl + barnFraPdl)
     }
 }

--- a/app/test/kotlin/tilgang/regler/RegelServiceTest.kt
+++ b/app/test/kotlin/tilgang/regler/RegelServiceTest.kt
@@ -10,12 +10,16 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import tilgang.AzureTokenGen
 import no.nav.aap.tilgang.Operasjon
+import no.nav.aap.tilgang.Rolle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
 import tilgang.fakes.Fakes
 import tilgang.integrasjoner.behandlingsflyt.IdenterRespons
 import tilgang.integrasjoner.msgraph.Group
 import tilgang.integrasjoner.msgraph.IMsGraphClient
 import tilgang.integrasjoner.msgraph.MemberOf
 import tilgang.integrasjoner.nom.INomClient
+import tilgang.integrasjoner.pdl.Gradering
 import tilgang.integrasjoner.pdl.HentGeografiskTilknytningResult
 import tilgang.integrasjoner.pdl.IPdlGraphQLClient
 import tilgang.integrasjoner.pdl.PdlGeoType
@@ -26,10 +30,18 @@ import tilgang.service.EnhetService
 import tilgang.service.GeoService
 import tilgang.service.SkjermingService
 import java.util.*
+import kotlin.test.Test
 
 class RegelServiceTest {
     companion object {
         private val FAKES = Fakes()
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            System.setProperty("fortrolig.adresse.ad", UUID.randomUUID().toString())
+            System.setProperty("strengt.fortrolig.adresse.ad", UUID.randomUUID().toString())
+        }
 
         @AfterAll
         @JvmStatic
@@ -70,6 +82,10 @@ class RegelServiceTest {
                         code = "XXX"
                     )
                 }
+            }
+
+            override fun hentBarnForPerson(personidenter: List<String>, callId: String): List<PersonResultat>? {
+                return null
             }
 
             override fun hentGeografiskTilknytning(
@@ -123,5 +139,119 @@ class RegelServiceTest {
         )
         Assertions.assertFalse(svar[Operasjon.SAKSBEHANDLE] == true)
 
+    }
+
+    @Test
+    fun `skal avslå tilgang til person dersom barn har adressebeskyttelse`() {
+        val graphClient = object : IMsGraphClient {
+            override fun hentAdGrupper(currentToken: OidcToken, ident: String): MemberOf {
+                return MemberOf(
+                    groups = listOf(
+                        Group(
+                            id = UUID.randomUUID(),
+                            name = "0000-GA-GEO_NASJONAL"
+                        )
+                    )
+                )
+            }
+        }
+
+        val geoService = GeoService(graphClient)
+        val prometheus = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+
+        val pdlService = object : IPdlGraphQLClient {
+            override fun hentPersonBolk(
+                personidenter: List<String>,
+                callId: String
+            ): List<PersonResultat> {
+                // Person har selv ikke adressebeskyttelse
+                return personidenter.map {
+                    PersonResultat(
+                        ident = it,
+                        adressebeskyttelse = listOf(),
+                        code = "XXX"
+                    )
+                }
+            }
+
+            override fun hentBarnForPerson(personidenter: List<String>, callId: String): List<PersonResultat>? {
+                // Person har barn med strengt fortrolig adresse
+                return listOf(PersonResultat(
+                    ident = "1234",
+                    adressebeskyttelse = listOf(Gradering.STRENGT_FORTROLIG),
+                    code = "XXX"
+                ))
+            }
+
+            override fun hentGeografiskTilknytning(
+                ident: String,
+                callId: String
+            ): HentGeografiskTilknytningResult {
+                return HentGeografiskTilknytningResult(
+                    gtType = PdlGeoType.KOMMUNE,
+                    gtLand = "NOR",
+                    gtBydel = null,
+                    gtKommune = "fff"
+                )
+            }
+        }
+        val enhetService = EnhetService(graphClient)
+        val skjermingClient = object : SkjermingClient(
+            FAKES.redis, prometheus
+        ) {
+            override fun isSkjermet(identer: IdenterRespons): Boolean {
+                return false
+            }
+        }
+        
+
+        val nomClient = object : INomClient {
+            override fun personNummerTilNavIdent(søkerIdent: String, callId: String): String {
+                return "T131785"
+            }
+        }
+
+        val skjermingService = SkjermingService(graphClient)
+
+        val regelService = RegelService(
+            geoService,
+            enhetService,
+            pdlService,
+            skjermingClient,
+            nomClient,
+            skjermingService,
+            AdressebeskyttelseService(graphClient)
+        )
+
+        val token = AzureTokenGen("tilgangazure", "tilgang").generate()
+        val regelInput = RegelInput(
+            callId = UUID.randomUUID().toString(),
+            ansattIdent = "123",
+            avklaringsbehovFraBehandlingsflyt = Definisjon.AVKLAR_SYKDOM,
+            avklaringsbehovFraPostmottak = null,
+            currentToken = OidcToken(token),
+            søkerIdenter = IdenterRespons(
+                søker = listOf("423", "456"),
+                barn = emptyList()
+            ),
+            operasjoner = listOf(Operasjon.SAKSBEHANDLE),
+            roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
+        )
+
+        // Barn-identer skal inkluderes i input til adressebeskyttelsesregel
+        val adressebeskyttelseInputGenerator = AdressebeskyttelseInputGenerator(
+            pdlService = pdlService,
+            adressebeskyttelseService = AdressebeskyttelseService(graphClient)
+        )
+
+        val adressebeskyttelseInput = adressebeskyttelseInputGenerator.generer(regelInput)
+        assertThat(adressebeskyttelseInput.personer.size).isEqualTo(3)
+        assertThat(adressebeskyttelseInput.personer.map { it.ident }).containsExactlyInAnyOrder("423", "456", "1234")
+
+        val svar = regelService.vurderTilgang(
+            regelInput,
+        )
+        // Tilgang skal avslås basert på barns adressebeskyttelse
+        assertThat(svar[Operasjon.SAKSBEHANDLE] != true)
     }
 }


### PR DESCRIPTION
Barn sendes ikke med fra behandlingsflyt før etter barnetilleggsteget. Må hente barn fra PDL for at adressebeskyttelsessjekken skal bli riktig