### PR TITLE
Bytt til Texas for tokenexchange for å få delt caching

### DIFF
--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangGateway.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangGateway.kt
@@ -7,7 +7,9 @@ import no.nav.aap.komponenter.httpklient.httpclient.post
 import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.OnBehalfOfTokenProvider
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.tokenx.OnBehalfOfTokenProvider as TexasOnBehalfOfTokenProvider
 import java.net.URI
+import no.nav.aap.komponenter.miljo.Miljø
 
 object TilgangGateway {
     private val baseUrl = URI.create(requiredConfigForKey("integrasjon.tilgang.url"))
@@ -15,7 +17,7 @@ object TilgangGateway {
 
     private val client = RestClient.withDefaultResponseHandler(
         config = config,
-        tokenProvider = OnBehalfOfTokenProvider,
+        tokenProvider = (if (Miljø.erProd()) OnBehalfOfTokenProvider else TexasOnBehalfOfTokenProvider()),
     )
 
     fun harTilgangTilSak(body: SakTilgangRequest, currentToken: OidcToken): TilgangResponse {


### PR DESCRIPTION
[Texas](https://doc.nais.io/auth/entra-id/how-to/consume-obo/#exchange-token) er en tjeneste fra nais-teamet for å veksle tokens. Texas vil cache for oss, på tvers av poder.

Fra traces ser det ut som veksling av tokens tar en del tid (observert av Henrik G senest i dag), så dette vil kunne redusere kall-tiden ganske betydelig.

TokenProvideren som bruker Texas har ikke noen spesiell håndtering for client credentials, men det er vel ikke relevant for disse endepunktene.