### PR TITLE
Aap 1466 tilgangsmaskin

### DIFF
--- a/app/main/kotlin/tilgang/App.kt
+++ b/app/main/kotlin/tilgang/App.kt
@@ -66,10 +66,10 @@ fun Application.api(
     val skjermingClient = SkjermingClient(redis, prometheus)
     val skjermingService = SkjermingService(msGraph)
     val nomClient = NomClient(redis, prometheus)
-    val regelService = RegelService(
-        geoService, enhetService, pdl, skjermingClient, nomClient, skjermingService, AdressebeskyttelseService(msGraph)
-    )
     val tilgangsmaskinClient = TilgangsmaskinClient()
+    val regelService = RegelService(
+        geoService, enhetService, pdl, skjermingClient, nomClient, skjermingService, AdressebeskyttelseService(msGraph), tilgangsmaskinClient
+    )
     val tilgangService = TilgangService(saf, behandlingsflyt, regelService, tilgangsmaskinClient)
 
     install(StatusPages) {

--- a/app/main/kotlin/tilgang/TilgangService.kt
+++ b/app/main/kotlin/tilgang/TilgangService.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import tilgang.integrasjoner.behandlingsflyt.BehandlingsflytClient
 import tilgang.integrasjoner.behandlingsflyt.IdenterRespons
 import tilgang.integrasjoner.tilgangsmaskin.BrukerOgRegeltype
+import tilgang.integrasjoner.tilgangsmaskin.HarTilgangFraTilgangsmaskinen
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinClient
 import tilgang.regler.RegelInput
 import tilgang.regler.RegelService
@@ -120,5 +121,10 @@ class TilgangService(
 
     fun harTilgangTilPerson(brukerIdent: String, token: OidcToken): Boolean {
         return tilgangsmaskinClient.harTilgangTilPerson(brukerIdent, token)
+    }
+
+    // Midlertidig testing
+    fun harTilgangFraTilgangsmaskinKjerne(brukerIdent: String, token: OidcToken): HarTilgangFraTilgangsmaskinen {
+        return tilgangsmaskinClient.harTilgangTilPersonKjerne(brukerIdent, token)
     }
 }

--- a/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinModell.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinModell.kt
@@ -1,0 +1,28 @@
+package tilgang.integrasjoner.tilgangsmaskin
+
+data class HarTilgangFraTilgangsmaskinen(
+    val harTilgang: Boolean,
+    val TilgangsmaskinAvvistResponse: TilgangsmaskinAvvistResponse? = null,
+)
+
+enum class TilgangsmaskinAvvistGrunn{
+    AVVIST_HABILITET,
+    AVVIST_STRENGT_FORTROLIG_ADRESSE,
+    AVVIST_STRENGT_FORTROLIG_UTLAND,
+    AVVIST_FORTROLIG_ADRESSE,
+    AVVIST_SKJERMING,
+    AVVIST_VERGE,
+    AVVIST_MANGLENDE_DATA
+}
+
+data class TilgangsmaskinAvvistResponse(
+    val type: String,
+    val title: String,
+    val status: Int,
+    val navIdent: String,
+    val begrunnelse: String,
+    val kanOverstyres: Boolean
+)
+
+data class TilgangsmaskinRequest(val brukerIdenter: List<BrukerOgRegeltype>)
+data class BrukerOgRegeltype(val brukerId: String, val type: String)

--- a/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinRequest.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinRequest.kt
@@ -1,4 +1,0 @@
-package tilgang.integrasjoner.tilgangsmaskin
-
-data class TilgangsmaskinRequest(val brukerIdenter: List<BrukerOgRegeltype>)
-data class BrukerOgRegeltype(val brukerId: String, val type: String)

--- a/app/main/kotlin/tilgang/regler/Regler.kt
+++ b/app/main/kotlin/tilgang/regler/Regler.kt
@@ -1,10 +1,12 @@
 package tilgang.regler
 
+import no.nav.aap.komponenter.miljo.Miljø.erProd
 import no.nav.aap.tilgang.Operasjon
 import org.slf4j.LoggerFactory
 import tilgang.integrasjoner.nom.INomClient
 import tilgang.integrasjoner.pdl.IPdlGraphQLClient
 import tilgang.integrasjoner.skjerming.SkjermingClient
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinClient
 import tilgang.service.AdressebeskyttelseService
 import tilgang.service.EnhetService
 import tilgang.service.GeoService
@@ -15,23 +17,34 @@ private val logger = LoggerFactory.getLogger(RegelService::class.java)
 class RegelService(
     geoService: GeoService,
     enhetService: EnhetService,
-    pdlService: IPdlGraphQLClient,
+    pdlClient: IPdlGraphQLClient,
     skjermetClient: SkjermingClient,
     nomClient: INomClient,
     skjermingService: SkjermingService,
-    adressebeskyttelseService: AdressebeskyttelseService
+    adressebeskyttelseService: AdressebeskyttelseService,
+    tilgangsmaskinClient: TilgangsmaskinClient
 ) {
     private val reglerForOperasjon = mapOf(
         Operasjon.SE to listOf(
             RegelMedInputgenerator(LeseRolleRegel, RolleInputGenerator),
             RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient)),
-            RegelMedInputgenerator(AdressebeskyttelseRegel, AdressebeskyttelseInputGenerator(pdlService, adressebeskyttelseService)),
-            RegelMedInputgenerator(GeoRegel, GeoInputGenerator(geoService, pdlService)),
+            /*if (erProd()) {
+                RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient))
+            } else {
+                RegelMedInputgenerator(TilgangsmaskinKjerneRegel, TilgangsmaskinKjerneInputGenerator(tilgangsmaskinClient))
+            },*/
+            RegelMedInputgenerator(AdressebeskyttelseRegel, AdressebeskyttelseInputGenerator(pdlClient, adressebeskyttelseService)),
+            RegelMedInputgenerator(GeoRegel, GeoInputGenerator(geoService, pdlClient)),
             RegelMedInputgenerator(EgenAnsattRegel, EgenAnsattInputGenerator(skjermetClient, skjermingService))
         ),
         Operasjon.DRIFTE to listOf(
             RegelMedInputgenerator(DriftRolleRegel, RolleInputGenerator),
-            RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient))
+            RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient)),
+            /*if (erProd()) {
+                RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient))
+            } else {
+                RegelMedInputgenerator(TilgangsmaskinKjerneRegel, TilgangsmaskinKjerneInputGenerator(tilgangsmaskinClient))
+            },*/
         ),
         Operasjon.DELEGERE to listOf(
             RegelMedInputgenerator(AvdelingslederRolleRegel, RolleInputGenerator),
@@ -39,8 +52,13 @@ class RegelService(
         Operasjon.SAKSBEHANDLE to listOf(
             RegelMedInputgenerator(AvklaringsbehovRolleRegel, AvklaringsbehovInputGenerator),
             RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient)),
-            RegelMedInputgenerator(AdressebeskyttelseRegel, AdressebeskyttelseInputGenerator(pdlService, adressebeskyttelseService)),
-            RegelMedInputgenerator(GeoRegel, GeoInputGenerator(geoService, pdlService)),
+            /*if (erProd()) {
+                RegelMedInputgenerator(EgenSakRegel, EgenSakInputGenerator(nomClient))
+            } else {
+                RegelMedInputgenerator(TilgangsmaskinKjerneRegel, TilgangsmaskinKjerneInputGenerator(tilgangsmaskinClient))
+            },*/
+            RegelMedInputgenerator(AdressebeskyttelseRegel, AdressebeskyttelseInputGenerator(pdlClient, adressebeskyttelseService)),
+            RegelMedInputgenerator(GeoRegel, GeoInputGenerator(geoService, pdlClient)),
             // TODO: Enhetsregelen gir kun mening hvis saker er knyttet mot enhet, noe de p.d. ikke er
             //RegelMedInputgenerator(EnhetRegel, EnhetInputGenerator(enhetService)),
             RegelMedInputgenerator(EgenAnsattRegel, EgenAnsattInputGenerator(skjermetClient, skjermingService))

--- a/app/main/kotlin/tilgang/regler/TilgangsmaskinKjerneRegel.kt
+++ b/app/main/kotlin/tilgang/regler/TilgangsmaskinKjerneRegel.kt
@@ -1,0 +1,30 @@
+package tilgang.regler
+
+import tilgang.integrasjoner.tilgangsmaskin.HarTilgangFraTilgangsmaskinen
+import tilgang.integrasjoner.tilgangsmaskin.ITilgangsmaskinClient
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistGrunn
+
+/*
+* Tilgangsmaskin-regel, per nå erstatter denne
+* EgenSakRegel (AVVIST_HABILITET)
+*
+* */
+data object TilgangsmaskinKjerneRegel : Regel<TilgangsmaskinKjerneInput> {
+    override fun vurder(input: TilgangsmaskinKjerneInput): Boolean {
+        val avvistMedHabilitetsgrunn =
+            input.tilgangsmaskinResponse.TilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString()
+
+        return input.tilgangsmaskinResponse.harTilgang || !avvistMedHabilitetsgrunn
+    }
+}
+
+class TilgangsmaskinKjerneInputGenerator(private val tilgangsmaskinClient: ITilgangsmaskinClient) :
+    InputGenerator<TilgangsmaskinKjerneInput> {
+    override fun generer(input: RegelInput): TilgangsmaskinKjerneInput {
+        val tilgangsmaskinResponse =
+            tilgangsmaskinClient.harTilgangTilPersonKjerne(input.ansattIdent, input.currentToken)
+        return TilgangsmaskinKjerneInput(tilgangsmaskinResponse)
+    }
+}
+
+data class TilgangsmaskinKjerneInput(var tilgangsmaskinResponse: HarTilgangFraTilgangsmaskinen)

--- a/app/main/kotlin/tilgang/routes/TilgangRoute.kt
+++ b/app/main/kotlin/tilgang/routes/TilgangRoute.kt
@@ -16,6 +16,7 @@ import tilgang.Role
 import tilgang.TilgangService
 import tilgang.auth.ident
 import tilgang.auth.roller
+import tilgang.integrasjoner.tilgangsmaskin.HarTilgangFraTilgangsmaskinen
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinRequest
 import tilgang.metrics.httpCallCounter
 import tilgang.metrics.nektetTilgangTeller
@@ -93,6 +94,15 @@ fun NormalOpenAPIRoute.tilgang(
                 val harTilgang =
                     tilgangService.harTilgangFraTilgangsmaskin(req.brukerIdenter, token())
                 respond(TilgangResponse(harTilgang))
+            }
+        }
+
+        // Midlertidig testing
+        route("/test/tilgangsmaskinhabiltest") {
+            post<Unit, HarTilgangFraTilgangsmaskinen, PersonTilgangRequest> { _, req ->
+                val harTilgang =
+                    tilgangService.harTilgangFraTilgangsmaskinKjerne(req.personIdent, token())
+                respond(harTilgang)
             }
         }
 

--- a/app/test/kotlin/tilgang/fakes/Fakes.kt
+++ b/app/test/kotlin/tilgang/fakes/Fakes.kt
@@ -11,6 +11,7 @@ class Fakes(azurePort: Int = 0) : AutoCloseable {
     private val log: Logger = LoggerFactory.getLogger(Fakes::class.java)
     private val azure = FakeServer(azurePort) { azureFake() }
     private val pdl = FakeServer(module = { pdlFake() })
+    private val tilgangsmaskin = FakeServer(module = { tilgangsmaskinFake() })
     val redis = Redis(InitTestRedis.uri)
     val prometheues = SimpleMeterRegistry()
 
@@ -23,8 +24,13 @@ class Fakes(azurePort: Int = 0) : AutoCloseable {
         System.setProperty("azure.openid.config.jwks.uri", "http://localhost:${azure.port()}/jwks")
         System.setProperty("azure.openid.config.issuer", "tilgang")
 
+        // PDL
         System.setProperty("pdl.base.url", "http://localhost:${pdl.port()}/graphql")
         System.setProperty("pdl.scope", "pdl")
+
+        // Tilgangsmaskinen
+        System.setProperty("integrasjon.tilgangsmaskin.url", "http://localhost:${tilgangsmaskin.port()}/api/v1/kjerne")
+        System.setProperty("integrasjon.tilgangsmaskin.scope", "tilgangsmaskin")
         
         // TODO: Lag fakes for disse
         System.setProperty("saf.base.url", "test")
@@ -37,8 +43,6 @@ class Fakes(azurePort: Int = 0) : AutoCloseable {
         System.setProperty("behandlingsflyt.base.url", "test")
         System.setProperty("ms.graph.scope", "msgraph")
         System.setProperty("ms.graph.base.url", "test")
-        System.setProperty("integrasjon.tilgangsmaskin.scope", "tilgangsmaskin")
-        System.setProperty("integrasjon.tilgangsmaskin.url", "tilgangsmaskin")
     }
 
     fun azurePort(): Int {
@@ -48,7 +52,7 @@ class Fakes(azurePort: Int = 0) : AutoCloseable {
     override fun close() {
         azure.stop()
         pdl.stop()
+        tilgangsmaskin.stop()
         redis.close()
     }
-
 }

--- a/app/test/kotlin/tilgang/fakes/Fakes.kt
+++ b/app/test/kotlin/tilgang/fakes/Fakes.kt
@@ -17,6 +17,8 @@ class Fakes(azurePort: Int = 0) : AutoCloseable {
 
     init {
         Thread.currentThread().setUncaughtExceptionHandler { _, e -> log.error("Uhåndtert feil", e) }
+
+        Runtime.getRuntime().addShutdownHook(Thread { close() })
         // Azure
         System.setProperty("azure.openid.config.token.endpoint", "http://localhost:${azure.port()}/token")
         System.setProperty("azure.app.client.id", "tilgang")

--- a/app/test/kotlin/tilgang/fakes/TilgangsmaskinFake.kt
+++ b/app/test/kotlin/tilgang/fakes/TilgangsmaskinFake.kt
@@ -1,0 +1,42 @@
+package tilgang.fakes
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistResponse
+
+fun Application.tilgangsmaskinFake() {
+    install(ContentNegotiation) {
+        jackson {
+            registerModule(JavaTimeModule())
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        }
+    }
+
+    routing {
+        post("/api/v1/kjerne") {
+            val body = call.receive<String>()
+            if (body.contains("123")) {
+                call.respond(HttpStatusCode.NoContent)
+            } else if (body.contains("456")) {
+                val body = TilgangsmaskinAvvistResponse (
+                    type = "https://confluence.adeo.no/display/TM/Tilgangsmaskin+API+og+regelsett",
+                    title = "AVVIST_HABILITET",
+                    status = 403,
+                    navIdent = "Z990883",
+                    begrunnelse = "Inhabil",
+                    kanOverstyres = false
+                )
+                call.respond(HttpStatusCode.Forbidden, body)
+            } else {
+                throw NotImplementedError("Mangler implementasjon")
+            }
+        }
+    }
+}

--- a/app/test/kotlin/tilgang/integrasjoner/PdlTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/PdlTest.kt
@@ -1,12 +1,22 @@
 package tilgang.integrasjoner
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
-import tilgang.fakes.WithFakes
-import tilgang.fakes.WithFakes.Companion.fakes
+import tilgang.fakes.Fakes
 import tilgang.integrasjoner.pdl.PdlGraphQLClient
 
-class PdlTest : WithFakes {
+class PdlTest {
+    companion object {
+        private val fakes = Fakes()
+
+        @AfterAll
+        @JvmStatic
+        fun afterall() {
+            fakes.close()
+        }
+    }
+
     @Test
     fun `Kan parse hentPersonBolk`() {
         val test =

--- a/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
@@ -1,6 +1,7 @@
 package tilgang.integrasjoner
 
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import tilgang.AzureTokenGen
 import tilgang.fakes.Fakes
@@ -10,7 +11,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TilgangsmaskinTest {
-    val fakes = Fakes()
+    companion object {
+        private val FAKES = Fakes()
+
+        @AfterAll
+        @JvmStatic
+        fun afterall() {
+            FAKES.close()
+        }
+    }
 
     @Test
     fun `Kan parse harTilgangTilPersonKjerne`() {

--- a/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
@@ -1,0 +1,22 @@
+package tilgang.integrasjoner
+
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
+import org.junit.jupiter.api.Test
+import tilgang.AzureTokenGen
+import tilgang.fakes.WithFakes
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistGrunn
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinClient
+import kotlin.test.assertTrue
+
+class TilgangsmaskinTest : WithFakes {
+    @Test
+    fun `Kan parse harTilgangTilPersonKjerne`() {
+        val token = AzureTokenGen("tilgangazure", "tilgang").generate()
+        val harTilgang = TilgangsmaskinClient().harTilgangTilPersonKjerne("123", OidcToken(token))
+        val harIkkeTilgang = TilgangsmaskinClient().harTilgangTilPersonKjerne("456", OidcToken(token))
+
+        assertTrue(harTilgang.harTilgang)
+        assertTrue(harIkkeTilgang.harTilgang)
+        assertTrue { harTilgang.TilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString() }
+    }
+}

--- a/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
@@ -3,13 +3,15 @@ package tilgang.integrasjoner
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import org.junit.jupiter.api.Test
 import tilgang.AzureTokenGen
-import tilgang.fakes.WithFakes
+import tilgang.fakes.Fakes
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistGrunn
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinClient
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class TilgangsmaskinTest : WithFakes {
+class TilgangsmaskinTest {
+    val fakes = Fakes()
+
     @Test
     fun `Kan parse harTilgangTilPersonKjerne`() {
         val token = AzureTokenGen("tilgangazure", "tilgang").generate()

--- a/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
@@ -6,17 +6,18 @@ import tilgang.AzureTokenGen
 import tilgang.fakes.WithFakes
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistGrunn
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinClient
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TilgangsmaskinTest : WithFakes {
     @Test
     fun `Kan parse harTilgangTilPersonKjerne`() {
         val token = AzureTokenGen("tilgangazure", "tilgang").generate()
-        val harTilgang = TilgangsmaskinClient().harTilgangTilPersonKjerne("123", OidcToken(token))
-        val harIkkeTilgang = TilgangsmaskinClient().harTilgangTilPersonKjerne("456", OidcToken(token))
+        val harTilgangResponse = TilgangsmaskinClient().harTilgangTilPersonKjerne("123", OidcToken(token))
+        val harIkkeTilgangResponse = TilgangsmaskinClient().harTilgangTilPersonKjerne("456", OidcToken(token))
 
-        assertTrue(harTilgang.harTilgang)
-        assertTrue(harIkkeTilgang.harTilgang)
-        assertTrue { harTilgang.TilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString() }
+        assertTrue(harTilgangResponse.harTilgang)
+        assertFalse(harIkkeTilgangResponse.harTilgang)
+        assertTrue(harIkkeTilgangResponse.TilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString())
     }
 }

--- a/app/test/kotlin/tilgang/regler/RegelServiceTest.kt
+++ b/app/test/kotlin/tilgang/regler/RegelServiceTest.kt
@@ -21,6 +21,7 @@ import tilgang.integrasjoner.pdl.IPdlGraphQLClient
 import tilgang.integrasjoner.pdl.PdlGeoType
 import tilgang.integrasjoner.pdl.PersonResultat
 import tilgang.integrasjoner.skjerming.SkjermingClient
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinClient
 import tilgang.service.AdressebeskyttelseService
 import tilgang.service.EnhetService
 import tilgang.service.GeoService
@@ -105,7 +106,8 @@ class RegelServiceTest {
             skjermingClient,
             nomClient,
             skjermingService,
-            AdressebeskyttelseService(graphClient)
+            AdressebeskyttelseService(graphClient),
+            TilgangsmaskinClient()
         )
 
         val token = AzureTokenGen("tilgangazure", "tilgang").generate()

--- a/app/test/kotlin/tilgang/regler/TilgangmaskinRegelTest.kt
+++ b/app/test/kotlin/tilgang/regler/TilgangmaskinRegelTest.kt
@@ -1,0 +1,51 @@
+package tilgang.regler
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import tilgang.integrasjoner.tilgangsmaskin.HarTilgangFraTilgangsmaskinen
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistGrunn
+import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinAvvistResponse
+
+class TilgangmaskinRegelTest {
+    @Test
+    fun `Skal avslå når avvist med grunn inhabil`() {
+        val input = TilgangsmaskinKjerneInput(
+            HarTilgangFraTilgangsmaskinen(
+                harTilgang = false,
+                TilgangsmaskinAvvistResponse(
+                    title = TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString(),
+                    status = 403,
+                    type = "type",
+                    navIdent = "Z990883",
+                    begrunnelse = "Inhabil",
+                    kanOverstyres = false
+                )
+            )
+        )
+        assertFalse(TilgangsmaskinKjerneRegel.vurder(input))
+    }
+
+    @Test
+    fun `Skal gi tilgang når avvist med grunn ulikt inhabil`() {
+        val input = TilgangsmaskinKjerneInput(
+            HarTilgangFraTilgangsmaskinen(
+                harTilgang = false,
+                TilgangsmaskinAvvistResponse(
+                    title = TilgangsmaskinAvvistGrunn.AVVIST_MANGLENDE_DATA.toString(),
+                    status = 403,
+                    type = "type",
+                    navIdent = "Z990883",
+                    begrunnelse = "Inhabil",
+                    kanOverstyres = false
+                )
+            )
+        )
+        assertTrue(TilgangsmaskinKjerneRegel.vurder(input))
+    }
+
+    @Test
+    fun `Skal gi tilgang når tilgangsmaskinen gir positivt svar`() {
+        val input = TilgangsmaskinKjerneInput(HarTilgangFraTilgangsmaskinen(true, null))
+        assertTrue(TilgangsmaskinKjerneRegel.vurder(input))
+    }
+}


### PR DESCRIPTION
Delvvis ta i bruk tilgangsmaskinen i regelvurderingene. I første omgang vil den kún ta over for regel EgenSakRegel, og da i tillegg støtte "nær familie", noe eksisterende regel ikke støtter.

Skal testes med endepunkter før regel kjøres ut i dev, derav midlertidig endepunkt og utkommenteringen av regelen.

Med tid kan vi erstatte flere av våre egne regler som dekkes greit nok i tilgangsmaskinen, ref disse:
https://confluence.adeo.no/spaces/TM/pages/621546888/Tilgangsmaskin+API+og+regelsett

    AVVIST_HABILITET, (skal nå støttes, tar over for EgenSakRegel)
    AVVIST_STRENGT_FORTROLIG_ADRESSE,
    AVVIST_STRENGT_FORTROLIG_UTLAND,
    AVVIST_FORTROLIG_ADRESSE,
    AVVIST_SKJERMING,
    AVVIST_VERGE,
    AVVIST_MANGLENDE_DATA
    
    