### PR TITLE
Tillat flere HTTP-metoder med TilgangPlugin på samme route

### DIFF
--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizedClient.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizedClient.kt
@@ -8,6 +8,7 @@ import com.papsign.ktor.openapigen.route.path.normal.get
 import com.papsign.ktor.openapigen.route.path.normal.post
 import com.papsign.ktor.openapigen.route.path.normal.put
 import com.papsign.ktor.openapigen.route.response.OpenAPIPipelineResponseContext
+import io.ktor.http.*
 import io.ktor.server.routing.*
 import no.nav.aap.tilgang.auditlog.AuditLogConfig
 import no.nav.aap.tilgang.auditlog.AuditLogPathParamConfig
@@ -26,16 +27,18 @@ inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.a
     noinline body: suspend OpenAPIPipelineResponseContext<TResponse>.(TParams) -> Unit
 ) {
     when (routeConfig) {
-        is RollerConfig -> ktorRoute.installerTilgangRollePlugin(routeConfig)
+        is RollerConfig -> ktorRoute.installerTilgangRollePlugin(routeConfig, HttpMethod.Get)
         is NoAuthConfig -> håndterNoAuth(this.ktorRoute, auditLogConfig)
         is AuthorizationParamPathConfig -> ktorRoute.installerTilgangParamPlugin(
             routeConfig,
-            if (auditLogConfig == null) null else auditLogConfig
+            if (auditLogConfig == null) null else auditLogConfig,
+            HttpMethod.Get
         )
 
         is AuthorizationMachineToMachineConfig -> ktorRoute.installerTilgangMachineToMachinePlugin(
             routeConfig,
-            auditLogConfig
+            auditLogConfig,
+            HttpMethod.Get
         )
 
         else -> throw IllegalArgumentException("Unsupported routeConfig type for GET: $routeConfig")
@@ -53,16 +56,18 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     when (routeConfig) {
         is AuthorizationParamPathConfig -> ktorRoute.installerTilgangParamPlugin(
             routeConfig,
-            if (auditLogConfig == null) null else auditLogConfig as AuditLogPathParamConfig
+            if (auditLogConfig == null) null else auditLogConfig as AuditLogPathParamConfig,
+            HttpMethod.Post
         )
 
-        is AuthorizationBodyPathConfig -> ktorRoute.installerTilgangBodyPlugin<TRequest>(routeConfig, auditLogConfig)
+        is AuthorizationBodyPathConfig -> ktorRoute.installerTilgangBodyPlugin<TRequest>(routeConfig, auditLogConfig, HttpMethod.Post)
         is AuthorizationMachineToMachineConfig -> ktorRoute.installerTilgangMachineToMachinePlugin(
             routeConfig,
-            auditLogConfig
+            auditLogConfig,
+            HttpMethod.Post
         )
 
-        is RollerConfig -> ktorRoute.installerTilgangRollePlugin(routeConfig)
+        is RollerConfig -> ktorRoute.installerTilgangRollePlugin(routeConfig, HttpMethod.Post)
         is NoAuthConfig -> håndterNoAuth(this.ktorRoute, auditLogConfig)
         else -> throw IllegalArgumentException("Unsupported routeConfig type for POST: $routeConfig")
     }
@@ -81,7 +86,7 @@ inline fun <reified TParams : Any, reified TResponse : Any> NormalOpenAPIRoute.g
         avklaringsbehovKode = avklaringsbehovKode,
         relevanteIdenterResolver = relevanteIdenterResolver,
         operasjonerIKontekst = listOf(
-        Operasjon.SAKSBEHANDLE)), null)
+        Operasjon.SAKSBEHANDLE)), null, HttpMethod.Get)
 
     @Suppress("UnauthorizedGet")
     get<TParams, TResponse>(*modules, tilgangkontrollertTag) { params -> body(params) }
@@ -96,16 +101,18 @@ inline fun <reified TParams : Any, reified TResponse : Any, reified TRequest : A
     when (routeConfig) {
         is AuthorizationParamPathConfig -> ktorRoute.installerTilgangParamPlugin(
             routeConfig,
-            if (auditLogConfig == null) null else auditLogConfig as AuditLogPathParamConfig
+            if (auditLogConfig == null) null else auditLogConfig as AuditLogPathParamConfig,
+            HttpMethod.Put
         )
 
-        is AuthorizationBodyPathConfig -> ktorRoute.installerTilgangBodyPlugin<TRequest>(routeConfig, auditLogConfig)
+        is AuthorizationBodyPathConfig -> ktorRoute.installerTilgangBodyPlugin<TRequest>(routeConfig, auditLogConfig, HttpMethod.Put)
         is AuthorizationMachineToMachineConfig -> ktorRoute.installerTilgangMachineToMachinePlugin(
             routeConfig,
-            auditLogConfig
+            auditLogConfig,
+            HttpMethod.Put
         )
         
-        is RollerConfig -> ktorRoute.installerTilgangRollePlugin(routeConfig)
+        is RollerConfig -> ktorRoute.installerTilgangRollePlugin(routeConfig, HttpMethod.Put)
         is NoAuthConfig -> håndterNoAuth(this.ktorRoute, auditLogConfig)
 
         else -> throw IllegalArgumentException("Unsupported routeConfig type for PUT: $routeConfig")

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.tilgang
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
@@ -29,15 +30,18 @@ val log: Logger = LoggerFactory.getLogger(TILGANG_PLUGIN)
 
 inline fun <reified T : Any> Route.installerTilgangBodyPlugin(
     pathConfig: AuthorizationBodyPathConfig,
-    auditLogConfig: AuditLogConfig?
+    auditLogConfig: AuditLogConfig?,
+    httpMethod: HttpMethod
 ) {
-    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(TILGANG_PLUGIN)) != null) {
-        throw IllegalStateException("Fant allerede registeret tilgang plugin")
+    val pluginName = "$TILGANG_PLUGIN-${httpMethod.value}"
+    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(pluginName)) != null) {
+        throw IllegalStateException("Fant allerede registeret tilgang plugin for ${httpMethod.value}")
     }
 
     install(DoubleReceive)
     install(
         buildTilgangPlugin(
+            httpMethod,
             auditLogConfig,
             { call: ApplicationCall -> pathConfig.tilTilgangRequest(call.parseGeneric<T>()) },
             { call: ApplicationCall ->
@@ -53,14 +57,17 @@ inline fun <reified T : Any> Route.installerTilgangBodyPlugin(
 
 fun Route.installerTilgangParamPlugin(
     config: AuthorizationParamPathConfig,
-    auditLogConfig: AuditLogPathParamConfig?
+    auditLogConfig: AuditLogPathParamConfig?,
+    httpMethod: HttpMethod
 ) {
-    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(TILGANG_PLUGIN)) != null) {
-        throw IllegalStateException("Fant allerede registeret tilgang plugin")
+    val pluginName = "$TILGANG_PLUGIN-${httpMethod.value}"
+    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(pluginName)) != null) {
+        throw IllegalStateException("Fant allerede registeret tilgang plugin for ${httpMethod.value}")
     }
 
     install(
         buildTilgangPlugin(
+            httpMethod,
             auditLogConfig,
             { call: ApplicationCall -> config.tilTilgangRequest(call.parameters) },
             { call: ApplicationCall -> auditLogConfig!!.tilIdent(call.parameters) }
@@ -69,14 +76,17 @@ fun Route.installerTilgangParamPlugin(
 }
 
 fun Route.installerTilgangRollePlugin(
-    config: RollerConfig
+    config: RollerConfig,
+    httpMethod: HttpMethod
 ) {
-    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(TILGANG_PLUGIN)) != null) {
-        throw IllegalStateException("Fant allerede registeret tilgang plugin")
+    val pluginName = "$TILGANG_PLUGIN-${httpMethod.value}"
+    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(pluginName)) != null) {
+        throw IllegalStateException("Fant allerede registeret tilgang plugin for ${httpMethod.value}")
     }
 
-    install(createRouteScopedPlugin(name = TILGANG_PLUGIN) {
+    install(createRouteScopedPlugin(name = pluginName) {
         on(AuthenticationChecked) { call ->
+            if (call.request.httpMethod != httpMethod) return@on
             val roller = call.groupsClaim()
 
             if (roller.any { adRolle -> adRolle in config.roller.map { it.id } }) {
@@ -90,17 +100,20 @@ fun Route.installerTilgangRollePlugin(
 fun Route.installerTilgangMachineToMachinePlugin(
     config: AuthorizationMachineToMachineConfig,
     auditLogConfig: AuditLogConfig?,
+    httpMethod: HttpMethod
 ) {
-    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(TILGANG_PLUGIN)) != null) {
-        throw IllegalStateException("Fant allerede registeret tilgang plugin")
+    val pluginName = "$TILGANG_PLUGIN-${httpMethod.value}"
+    if ((this as RoutingNode).pluginRegistry.getOrNull(AttributeKey(pluginName)) != null) {
+        throw IllegalStateException("Fant allerede registeret tilgang plugin for ${httpMethod.value}")
     }
 
     require(auditLogConfig == null) {
         "kan ikke installere audit-logger for maskin-til-maskin tokens uten on-behalf-of tokens (m2m obo tokens)"
     }
 
-    install(createRouteScopedPlugin(name = TILGANG_PLUGIN) {
+    install(createRouteScopedPlugin(name = pluginName) {
         on(AuthenticationChecked) { call ->
+            if (call.request.httpMethod != httpMethod) return@on
             val principal = call.principal<JWTPrincipal>() ?: error("mangler principal")
 
             if (config.authorizedAzps.isNotEmpty()) {
@@ -131,12 +144,15 @@ fun Route.installerTilgangMachineToMachinePlugin(
 
 
 inline fun buildTilgangPlugin(
+    httpMethod: HttpMethod,
     auditLogConfig: AuditLogConfig?,
     crossinline parse: suspend (call: ApplicationCall) -> AuthorizedRequest,
     crossinline resolveIdent: suspend (call: ApplicationCall) -> String
 ): RouteScopedPlugin<Unit> {
-    return createRouteScopedPlugin(name = TILGANG_PLUGIN) {
+    val pluginName = "$TILGANG_PLUGIN-${httpMethod.value}"
+    return createRouteScopedPlugin(name = pluginName) {
         on(AuthenticationChecked) { call ->
+            if (call.request.httpMethod != httpMethod) return@on
             val token = call.token()
             val input = parse(call)
             val harTilgang = TilgangService.harTilgang(input, call, token)

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -39,6 +39,13 @@ fun Application.autorisertEksempelApp() {
                     ) {
                         respond(IngenReferanse("test"))
                     }
+                    authorizedPost<Unit, IngenReferanse, IngenReferanse>(
+                        RollerConfig(
+                            listOf(Beslutter)
+                        )
+                    ) { _, dto ->
+                        respond(IngenReferanse("post-${dto.noe}"))
+                    }
                 }
 
                 route("testApi/getGrunnlag/{referanse}") {

--- a/plugin/src/test/kotlin/TilgangPluginTest.kt
+++ b/plugin/src/test/kotlin/TilgangPluginTest.kt
@@ -129,6 +129,47 @@ class TilgangPluginTest {
     }
 
     @Test
+    fun `Skal gi tilgang basert på rolle for POST på samme route som GET`() {
+        val token = generateToken(isApp = false, roles = listOf(Beslutter.id))
+
+        val res = clientUtenTokenProvider.post<_, IngenReferanse>(
+            URI.create("http://localhost:8082/")
+                .resolve("kun-roller"),
+            PostRequest(
+                body = IngenReferanse("input"),
+                additionalHeaders = listOf(
+                    Header(
+                        "Authorization",
+                        "Bearer ${token.token()}"
+                    )
+                )
+            )
+        )
+
+        assertThat(res?.noe).isEqualTo("post-input")
+    }
+
+    @Test
+    fun `Skal ikke gi tilgang for manglende rolle på POST på samme route som GET`() {
+        val token = generateToken(isApp = false, roles = listOf("ikke-riktig-rolle"))
+        assertThrows<ManglerTilgangException> {
+            clientUtenTokenProvider.post<_, IngenReferanse>(
+                URI.create("http://localhost:8082/")
+                    .resolve("kun-roller"),
+                PostRequest(
+                    body = IngenReferanse("input"),
+                    additionalHeaders = listOf(
+                        Header(
+                            "Authorization",
+                            "Bearer ${token.token()}"
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
     fun `Skal ikke gi tilgang for manglende rolle`() {
         val token = generateToken(isApp = false, roles = listOf("ikke-riktig-rolle"))
         assertThrows<ManglerTilgangException> {


### PR DESCRIPTION
Gjør pluginnavn metodespesifikke (f.eks. TilgangPlugin-GET, TilgangPlugin-POST) og filtrer på HTTP-metode i hver plugin-handler, slik at authorizedGet, authorizedPost og authorizedPut kan sameksistere på samme route.

Gjør det mulig å ha flere endepunkter med tilgangsstyring på samme route-path:
Feks `GET /api/meldekort/{saksnummer}` og `POST /api/meldekort/{saksnummer}`. Dette ville tidligere feilet for `installerTilgang*Plugin` sjekker om det finnes en installert tilgang på pathen fra før.  