### PR TITLE
Legg til påkrevdRolle på tilgangsforespørsler

### DIFF
--- a/.run/dev-gcp.run.xml
+++ b/.run/dev-gcp.run.xml
@@ -11,7 +11,7 @@
       <env name="BEHANDLINGSFLYT_BASE_URL" value="http://localhost:8080" />
       <env name="BEHANDLINGSFLYT_SCOPE" value="api://dev-gcp.aap.behandlingsflyt/.default" />
       <env name="FORTROLIG_ADRESSE_AD" value="ea930b6b-9397-44d9-b9e6-f4cf527a632a" />
-      <env name="INTEGRASJON_TILGANGSMASKIN_URL" value="https://tilgangsmaskin.intern.dev.nav.no" />
+      <env name="INTEGRASJON_TILGANGSMASKIN_URL" value="http://populasjonstilgangskontroll.tilgangsmaskin" />
       <env name="MS_GRAPH_BASE_URL" value="https://graph.microsoft.com/v1.0/" />
       <env name="MS_GRAPH_SCOPE" value="https://graph.microsoft.com/.default" />
       <env name="NAIS_APP_NAME" value="tilgang" />
@@ -31,11 +31,10 @@
       <env name="SKJERMING_BASE_URL" value="https://skjermede-personer-pip.intern.dev.nav.no" />
       <env name="SKJERMING_SCOPE" value="api://dev-gcp.nom.skjermede-personer-pip/.default" />
       <env name="STRENGT_FORTROLIG_ADRESSE_AD" value="5ef775f2-61f8-4283-bf3d-8d03f428aa14" />
-      <env name="INTEGRASJON_TILGANGSMASKIN_URL" value="http://populasjonstilgangskontroll.tilgangsmaskin" />
       <env name="INTEGRASJON_TILGANGSMASKIN_SCOPE" value="api://dev-gcp.tilgangsmaskin.populasjonstilgangskontroll/.default" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="tilgang.AppKt" />
-    <module name="aap-tilgang.app.main" />
+    <module name="tilgang.app.main" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="true" />
       <option name="IS_SUBST" value="false" />

--- a/.run/dev-gcp.run.xml
+++ b/.run/dev-gcp.run.xml
@@ -11,7 +11,7 @@
       <env name="BEHANDLINGSFLYT_BASE_URL" value="http://localhost:8080" />
       <env name="BEHANDLINGSFLYT_SCOPE" value="api://dev-gcp.aap.behandlingsflyt/.default" />
       <env name="FORTROLIG_ADRESSE_AD" value="ea930b6b-9397-44d9-b9e6-f4cf527a632a" />
-      <env name="INTEGRASJON_TILGANGSMASKIN_URL" value="http://populasjonstilgangskontroll.tilgangsmaskin" />
+      <env name="INTEGRASJON_TILGANGSMASKIN_URL" value="https://tilgangsmaskin.intern.dev.nav.no" />
       <env name="MS_GRAPH_BASE_URL" value="https://graph.microsoft.com/v1.0/" />
       <env name="MS_GRAPH_SCOPE" value="https://graph.microsoft.com/.default" />
       <env name="NAIS_APP_NAME" value="tilgang" />

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/tilgang/TilgangRequest.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/tilgang/TilgangRequest.kt
@@ -6,6 +6,7 @@ sealed interface TilgangRequest
 
 data class SakTilgangRequest(
     val saksnummer: String,
+    val påkrevdRolle: Rolle? = null,
     val operasjon: Operasjon,
     /**
      * Valgfritt felt for å spesifisere relevante identer knyttet til saken.
@@ -17,6 +18,7 @@ data class SakTilgangRequest(
 data class BehandlingTilgangRequest(
     val behandlingsreferanse: UUID,
     val avklaringsbehovKode: String?,
+    val påkrevdRolle: Rolle? = null,
     val operasjon: Operasjon,
     /**
      * Valgfritt felt for å spesifisere relevante identer knyttet til saken.
@@ -29,6 +31,7 @@ data class BehandlingTilgangRequest(
 data class JournalpostTilgangRequest(
     val journalpostId: Long,
     val avklaringsbehovKode: String?,
+    val påkrevdRolle: Rolle? = null,
     val operasjon: Operasjon
 ) : TilgangRequest
 

--- a/app/main/kotlin/tilgang/TilgangService.kt
+++ b/app/main/kotlin/tilgang/TilgangService.kt
@@ -47,7 +47,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = null, 
-            påkrevdRolle = null,
+            påkrevdRolle = req.påkrevdRolle,
             operasjoner = listOf(req.operasjon)
         )
         return regelService.vurderTilgang(regelInput)[req.operasjon] == true
@@ -75,7 +75,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = avklaringsbehov,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = null,
+            påkrevdRolle = req.påkrevdRolle,
             operasjoner = (req.operasjonerIKontekst + req.operasjon).toSet().toList()
         )
         return regelService.vurderTilgang(regelInput)
@@ -109,7 +109,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = avklaringsbehov,
-            påkrevdRolle = null,
+            påkrevdRolle = req.påkrevdRolle,
             operasjoner = listOf(req.operasjon),
         )
         return regelService.vurderTilgang(regelInput)[req.operasjon] == true

--- a/app/main/kotlin/tilgang/regler/AvklaringsbehovRolleRegel.kt
+++ b/app/main/kotlin/tilgang/regler/AvklaringsbehovRolleRegel.kt
@@ -7,13 +7,20 @@ import no.nav.aap.tilgang.Rolle
 data object AvklaringsbehovRolleRegel : Regel<AvklaringsbehovRolleInput> {
     override fun vurder(input: AvklaringsbehovRolleInput): Boolean {
         require(input.avklaringsbehovFraBehandlingsflyt != null || input.avklaringsbehovFraPostmottak != null || input.påkrevdRolle != null) { "Avklaringsbehov eller påkrevd rolle må være satt" }
-        if (input.avklaringsbehovFraBehandlingsflyt != null) {
-            return kanAvklareBehov(input.avklaringsbehovFraBehandlingsflyt, input.roller)
-        } else if (input.avklaringsbehovFraPostmottak != null){
-            return kanAvklareBehov(input.avklaringsbehovFraPostmottak, input.roller)
-        } else {
-            return input.roller.contains(input.påkrevdRolle)
+
+        val harRolleForAvklaringsbehov = when {
+            input.avklaringsbehovFraBehandlingsflyt != null -> kanAvklareBehov(input.avklaringsbehovFraBehandlingsflyt, input.roller)
+            input.avklaringsbehovFraPostmottak != null -> kanAvklareBehov(input.avklaringsbehovFraPostmottak, input.roller)
+            else -> true
         }
+
+        val harPåkrevdRolle = if (input.påkrevdRolle != null) {
+            input.roller.contains(input.påkrevdRolle)
+        } else {
+            true
+        }
+
+        return harRolleForAvklaringsbehov && harPåkrevdRolle
     }
 
     private fun kanAvklareBehov(avklaringsbehov: Definisjon, roller: List<Rolle>): Boolean {

--- a/app/main/kotlin/tilgang/regler/AvklaringsbehovRolleRegel.kt
+++ b/app/main/kotlin/tilgang/regler/AvklaringsbehovRolleRegel.kt
@@ -1,26 +1,25 @@
 package tilgang.regler
 
 import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
-import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon as PostmottakDefinisjon
 import no.nav.aap.tilgang.Rolle
+import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon as PostmottakDefinisjon
 
 data object AvklaringsbehovRolleRegel : Regel<AvklaringsbehovRolleInput> {
     override fun vurder(input: AvklaringsbehovRolleInput): Boolean {
-        require(input.avklaringsbehovFraBehandlingsflyt != null || input.avklaringsbehovFraPostmottak != null || input.påkrevdRolle != null) { "Avklaringsbehov eller påkrevd rolle må være satt" }
+        val sjekker = mutableListOf<Boolean>()
 
-        val harRolleForAvklaringsbehov = when {
-            input.avklaringsbehovFraBehandlingsflyt != null -> kanAvklareBehov(input.avklaringsbehovFraBehandlingsflyt, input.roller)
-            input.avklaringsbehovFraPostmottak != null -> kanAvklareBehov(input.avklaringsbehovFraPostmottak, input.roller)
-            else -> true
+        if (input.avklaringsbehovFraBehandlingsflyt != null) {
+            sjekker.add(kanAvklareBehov(input.avklaringsbehovFraBehandlingsflyt, input.roller))
+        }
+        if (input.avklaringsbehovFraPostmottak != null) {
+            sjekker.add(kanAvklareBehov(input.avklaringsbehovFraPostmottak, input.roller))
+        }
+        if (input.påkrevdRolle != null) {
+            sjekker.add(input.roller.contains(input.påkrevdRolle))
         }
 
-        val harPåkrevdRolle = if (input.påkrevdRolle != null) {
-            input.roller.contains(input.påkrevdRolle)
-        } else {
-            true
-        }
-
-        return harRolleForAvklaringsbehov && harPåkrevdRolle
+        require(sjekker.isNotEmpty()) { "Avklaringsbehov eller påkrevd rolle må være satt" }
+        return sjekker.all { it }
     }
 
     private fun kanAvklareBehov(avklaringsbehov: Definisjon, roller: List<Rolle>): Boolean {

--- a/app/main/kotlin/tilgang/routes/TilgangRoute.kt
+++ b/app/main/kotlin/tilgang/routes/TilgangRoute.kt
@@ -68,8 +68,8 @@ fun NormalOpenAPIRoute.tilgang(
             post<Unit, TilgangResponse, JournalpostTilgangRequest> { _, req ->
                 prometheus.httpCallCounter(pipeline.call).increment()
 
-                if (req.operasjon == Operasjon.SAKSBEHANDLE && req.avklaringsbehovKode == null) {
-                    log.info("Kan ikke saksbehandle uten avklaringsbehov $req")
+                if (req.operasjon == Operasjon.SAKSBEHANDLE && req.avklaringsbehovKode == null && req.påkrevdRolle == null) {
+                    log.info("Kan ikke saksbehandle uten avklaringsbehov eller påkrevd rolle $req")
                     respondWithStatus(HttpStatusCode.BadRequest)
                 }
 

--- a/app/test/kotlin/tilgang/regler/AvklaringsbehovRolleRegelTest.kt
+++ b/app/test/kotlin/tilgang/regler/AvklaringsbehovRolleRegelTest.kt
@@ -1,0 +1,79 @@
+package tilgang.regler
+
+import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
+import no.nav.aap.tilgang.Rolle
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AvklaringsbehovRolleRegelTest {
+
+    @Test
+    fun `gir tilgang når bruker har riktig rolle for avklaringsbehov fra behandlingsflyt`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = null,
+            roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
+        )
+        assertTrue(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `gir ikke tilgang når bruker mangler rolle for avklaringsbehov fra behandlingsflyt`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = null,
+            roller = listOf(Rolle.BESLUTTER)
+        )
+        assertFalse(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `gir tilgang med påkrevdRolle når bruker har rollen`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = null,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = Rolle.BESLUTTER,
+            roller = listOf(Rolle.BESLUTTER)
+        )
+        assertTrue(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `gir ikke tilgang med påkrevdRolle når bruker mangler rollen`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = null,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = Rolle.BESLUTTER,
+            roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
+        )
+        assertFalse(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `avklaringsbehov fra behandlingsflyt har prioritet over påkrevdRolle`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = Rolle.BESLUTTER,
+            roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
+        )
+        // Avklaringsbehov brukes, ikke påkrevdRolle — SAKSBEHANDLER_OPPFOLGING kan løse MANUELT_SATT_PÅ_VENT
+        assertTrue(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `kaster feil når verken avklaringsbehov eller påkrevdRolle er satt`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = null,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = null,
+            roller = listOf(Rolle.BESLUTTER)
+        )
+        assertThrows<IllegalArgumentException> {
+            AvklaringsbehovRolleRegel.vurder(input)
+        }
+    }
+}

--- a/app/test/kotlin/tilgang/regler/AvklaringsbehovRolleRegelTest.kt
+++ b/app/test/kotlin/tilgang/regler/AvklaringsbehovRolleRegelTest.kt
@@ -53,15 +53,37 @@ class AvklaringsbehovRolleRegelTest {
     }
 
     @Test
-    fun `avklaringsbehov fra behandlingsflyt har prioritet over påkrevdRolle`() {
+    fun `krever både avklaringsbehov-rolle og påkrevdRolle når begge er satt`() {
+        // Bruker har SAKSBEHANDLER_OPPFOLGING som kan løse MANUELT_SATT_PÅ_VENT, og BESLUTTER som er påkrevdRolle
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = Rolle.BESLUTTER,
+            roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING, Rolle.BESLUTTER)
+        )
+        assertTrue(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `gir ikke tilgang når avklaringsbehov passer men påkrevdRolle mangler`() {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
             avklaringsbehovFraPostmottak = null,
             påkrevdRolle = Rolle.BESLUTTER,
             roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
         )
-        // Avklaringsbehov brukes, ikke påkrevdRolle — SAKSBEHANDLER_OPPFOLGING kan løse MANUELT_SATT_PÅ_VENT
-        assertTrue(AvklaringsbehovRolleRegel.vurder(input))
+        assertFalse(AvklaringsbehovRolleRegel.vurder(input))
+    }
+
+    @Test
+    fun `gir ikke tilgang når påkrevdRolle passer men avklaringsbehov-rolle mangler`() {
+        val input = AvklaringsbehovRolleInput(
+            avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
+            avklaringsbehovFraPostmottak = null,
+            påkrevdRolle = Rolle.BESLUTTER,
+            roller = listOf(Rolle.BESLUTTER)
+        )
+        assertFalse(AvklaringsbehovRolleRegel.vurder(input))
     }
 
     @Test

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationBodyPathConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationBodyPathConfig.kt
@@ -12,6 +12,7 @@ data class AuthorizationBodyPathConfig(
     val operasjon: Operasjon,
     val applicationRole: String? = null,
     val applicationsOnly: Boolean = false,
+    val påkrevdRolle: Rolle? = null,
     val relevanteIdenterResolver: RelevanteIdenterResolver? = null,
     val journalpostIdResolver: JournalpostIdResolver = DefaultJournalpostIdResolver(),
     val behandlingreferanseResolver: BehandlingreferanseResolver = DefaultBehandlingreferanseResolver()
@@ -24,7 +25,7 @@ data class AuthorizationBodyPathConfig(
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
-                    SakTilgangRequest(referanse, operasjon, relevanteIdenter)
+                    SakTilgangRequest(saksnummer = referanse, påkrevdRolle = påkrevdRolle, operasjon = operasjon, relevanteIdenter = relevanteIdenter)
                 )
             }
 
@@ -44,7 +45,7 @@ data class AuthorizationBodyPathConfig(
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
-                    BehandlingTilgangRequest(referanse, avklaringsbehovKode, operasjon, relevanteIdenter)
+                    BehandlingTilgangRequest(behandlingsreferanse = referanse, avklaringsbehovKode = avklaringsbehovKode, påkrevdRolle = påkrevdRolle, operasjon = operasjon, relevanteIdenter = relevanteIdenter)
                 )
             }
 
@@ -55,7 +56,7 @@ data class AuthorizationBodyPathConfig(
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
-                    JournalpostTilgangRequest(referanse, avklaringsbehovKode, operasjon)
+                    JournalpostTilgangRequest(journalpostId = referanse, avklaringsbehovKode = avklaringsbehovKode, påkrevdRolle = påkrevdRolle, operasjon = operasjon)
                 )
             }
 

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationParamPathConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationParamPathConfig.kt
@@ -13,6 +13,7 @@ data class AuthorizationParamPathConfig(
     val operasjon: Operasjon = Operasjon.SE,
     val operasjonerIKontekst: List<Operasjon> = emptyList(),
     val avklaringsbehovKode: String? = null,
+    val påkrevdRolle: Rolle? = null,
     val applicationRole: String? = null,
     val applicationsOnly: Boolean = false,
     val sakPathParam: SakPathParam? = null,
@@ -21,8 +22,8 @@ data class AuthorizationParamPathConfig(
     val journalpostPathParam: JournalpostPathParam? = null,
 ) : AuthorizationRouteConfig {
     init {
-        require(operasjon != Operasjon.SAKSBEHANDLE || avklaringsbehovKode != null) {
-            "Avklaringsbehovkode må være satt for operasjon SAKSBEHANDLE"
+        require(operasjon != Operasjon.SAKSBEHANDLE || avklaringsbehovKode != null || påkrevdRolle != null) {
+            "Avklaringsbehovkode eller påkrevdRolle må være satt for operasjon SAKSBEHANDLE"
         }
         if (applicationsOnly) {
             requireNotNull(applicationRole) {
@@ -41,7 +42,8 @@ data class AuthorizationParamPathConfig(
                 SakTilgangRequest(
                     relevanteIdenter = relevanteIdenter,
                     saksnummer = saksnummer,
-                    operasjon = operasjon
+                    operasjon = operasjon,
+                    påkrevdRolle = påkrevdRolle,
                 )
             )
         }
@@ -56,6 +58,7 @@ data class AuthorizationParamPathConfig(
                     behandlingsreferanse = behandlingsreferanse,
                     operasjon = operasjon,
                     avklaringsbehovKode = avklaringsbehovKode,
+                    påkrevdRolle = påkrevdRolle,
                     operasjonerIKontekst = operasjonerIKontekst
                 )
             )
@@ -69,7 +72,8 @@ data class AuthorizationParamPathConfig(
                 JournalpostTilgangRequest(
                     journalpostId = journalpostId,
                     operasjon = operasjon,
-                    avklaringsbehovKode = avklaringsbehovKode
+                    avklaringsbehovKode = avklaringsbehovKode,
+                    påkrevdRolle = påkrevdRolle
                 )
             )
         }

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -193,6 +193,29 @@ fun Application.autorisertEksempelApp() {
                         }
                     }
                 }
+                route("testApi/påkrevdRolle") {
+                    route("sak/{saksnummer}") {
+                        authorizedGet<TestReferanse, Saksinfo>(
+                            AuthorizationParamPathConfig(
+                                operasjon = Operasjon.SAKSBEHANDLE,
+                                påkrevdRolle = Rolle.BESLUTTER,
+                                sakPathParam = SakPathParam("saksnummer")
+                            ),
+                        ) { req ->
+                            respond(Saksinfo(saksnummer = req.saksnummer))
+                        }
+                    }
+                    route("sak/post") {
+                        authorizedPost<Unit, Saksinfo, Saksinfo>(
+                            AuthorizationBodyPathConfig(
+                                operasjon = Operasjon.SAKSBEHANDLE,
+                                påkrevdRolle = Rolle.BESLUTTER,
+                            )
+                        ) { _, dto ->
+                            respond(dto)
+                        }
+                    }
+                }
                 route("testApi/authorizedPost") {
                     route("on-behalf-of/saksinfo") {
                         authorizedPost<Unit, Saksinfo, Saksinfo>(

--- a/plugin/src/test/kotlin/Fakes.kt
+++ b/plugin/src/test/kotlin/Fakes.kt
@@ -56,6 +56,9 @@ internal class Fakes(val azureTokenGen: AzureTokenGen) : AutoCloseable {
     }
 
     private val tilgangTilSak = mutableMapOf<String, Boolean>()
+    var sistMottattSakTilgangRequest: SakTilgangRequest? = null
+        private set
+
     fun gittTilgangTilSak(sak: String, tilgang: Boolean) {
         tilgangTilSak[sak] = tilgang
     }
@@ -96,8 +99,8 @@ internal class Fakes(val azureTokenGen: AzureTokenGen) : AutoCloseable {
         }
         routing {
             post("/tilgang/sak") {
-                // TODO: Test kontrakten på en litt mer fornuftig måte
                 val req = call.receive<SakTilgangRequest>()
+                sistMottattSakTilgangRequest = req
                 call.respond(TilgangResponse(tilgangTilSak[req.saksnummer] == true))
             }
             post("/tilgang/behandling") {

--- a/plugin/src/test/kotlin/TilgangPluginTest.kt
+++ b/plugin/src/test/kotlin/TilgangPluginTest.kt
@@ -536,6 +536,58 @@ class TilgangPluginTest {
     }
 
     @Test
+    fun `get sak med påkrevdRolle gir tilgang`() {
+        val randomUuid = UUID.randomUUID()
+        fakes.gittTilgangTilSak(randomUuid.toString(), true)
+        val res = clientForOBO.get<Saksinfo>(
+            URI.create("http://localhost:8082/")
+                .resolve("testApi/påkrevdRolle/sak/$randomUuid"),
+            GetRequest(currentToken = generateToken(isApp = false))
+        )
+
+        assertThat(res?.saksnummer).isEqualTo(randomUuid)
+        assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(Rolle.BESLUTTER)
+    }
+
+    @Test
+    fun `get sak med påkrevdRolle gir ikke tilgang`() {
+        val randomUuid = UUID.randomUUID()
+        assertThrows<ManglerTilgangException> {
+            clientForOBO.get<Saksinfo>(
+                URI.create("http://localhost:8082/")
+                    .resolve("testApi/påkrevdRolle/sak/$randomUuid"),
+                GetRequest(currentToken = generateToken(isApp = false))
+            )
+        }
+    }
+
+    @Test
+    fun `post sak med påkrevdRolle gir tilgang`() {
+        val randomUuid = UUID.randomUUID()
+        fakes.gittTilgangTilSak(randomUuid.toString(), true)
+        val res = clientForOBO.post<_, Saksinfo>(
+            URI.create("http://localhost:8082/")
+                .resolve("testApi/påkrevdRolle/sak/post"),
+            PostRequest(Saksinfo(randomUuid), currentToken = generateToken(isApp = false))
+        )
+
+        assertThat(res?.saksnummer).isEqualTo(randomUuid)
+        assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(Rolle.BESLUTTER)
+    }
+
+    @Test
+    fun `post sak med påkrevdRolle gir ikke tilgang`() {
+        val randomUuid = UUID.randomUUID()
+        assertThrows<ManglerTilgangException> {
+            clientForOBO.post<_, Saksinfo>(
+                URI.create("http://localhost:8082/")
+                    .resolve("testApi/påkrevdRolle/sak/post"),
+                PostRequest(Saksinfo(randomUuid), currentToken = generateToken(isApp = false))
+            )
+        }
+    }
+
+    @Test
     fun `skal returnere json ved ikke tilgang`() {
         val randomUuid = UUID.randomUUID()
         assertThatThrownBy {


### PR DESCRIPTION
Behovet oppstår eksempelvis i tilfellene hvor man trenger å gjøre en request som ikke er direkte koblet til et avklaringsbehov. Dette gjelder for eksempel i tilfeller hvor saksbehandler gjør operasjoner direkte på sak. Viderefører `påkrevdRolle` som allerede var brukt for tilbakekreving, men utvider da med støtte i plugin og for øvrige endepunkter i tilgang-api.

- Legger til påkrevdRolle på SakTilgangRequest, BehandlingTilgangRequest og JournalpostTilgangRequest
- Kobler påkrevdRolle gjennom AuthorizationBodyPathConfig og AuthorizationParamPathConfig
- Oppdaterer TilgangService til å sende påkrevdRolle videre til RegelInput
- Oppdaterer validering i TilgangRoute til å akseptere påkrevdRolle som alternativ til avklaringsbehovKode
- Legger til tester for AvklaringsbehovRolleRegel og plugin-integrasjon