### PR TITLE
Gjøre påkrevd rolle til liste som også er nullable for bakoverkompabilitet

### DIFF
--- a/api-kontrakt/src/main/kotlin/no/nav/aap/tilgang/TilgangRequest.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/tilgang/TilgangRequest.kt
@@ -6,7 +6,7 @@ sealed interface TilgangRequest
 
 data class SakTilgangRequest(
     val saksnummer: String,
-    val påkrevdRolle: List<Rolle> = emptyList(),
+    val påkrevdRolle: List<Rolle>? = null,
     val operasjon: Operasjon,
     /**
      * Valgfritt felt for å spesifisere relevante identer knyttet til saken.
@@ -18,7 +18,7 @@ data class SakTilgangRequest(
 data class BehandlingTilgangRequest(
     val behandlingsreferanse: UUID,
     val avklaringsbehovKode: String?,
-    val påkrevdRolle: List<Rolle> = emptyList(),
+    val påkrevdRolle: List<Rolle>? = null,
     val operasjon: Operasjon,
     /**
      * Valgfritt felt for å spesifisere relevante identer knyttet til saken.
@@ -31,7 +31,7 @@ data class BehandlingTilgangRequest(
 data class JournalpostTilgangRequest(
     val journalpostId: Long,
     val avklaringsbehovKode: String?,
-    val påkrevdRolle: List<Rolle> = emptyList(),
+    val påkrevdRolle: List<Rolle>? = null,
     val operasjon: Operasjon
 ) : TilgangRequest
 
@@ -44,11 +44,11 @@ data class TilbakekrevingTilgangRequest(
     val behandlingsreferanse: UUID,
     @Deprecated("Trengs for bakoverkompabilitet da denne allerede er i bruk")
     val påkrevdRolle: Rolle? = null,
-    val påkrevdRoller: List<Rolle> = emptyList(),
+    val påkrevdRoller: List<Rolle>? = null,
     val operasjon: Operasjon,
 ) : TilgangRequest {
     val effektivePåkrevdRoller: List<Rolle>
-        get() = påkrevdRoller.ifEmpty { listOfNotNull(påkrevdRolle) }
+        get() = påkrevdRoller?.ifEmpty { null } ?: listOfNotNull(påkrevdRolle)
 
     init {
         if (operasjon == Operasjon.SAKSBEHANDLE) {

--- a/api-kontrakt/src/main/kotlin/no/nav/aap/tilgang/TilgangRequest.kt
+++ b/api-kontrakt/src/main/kotlin/no/nav/aap/tilgang/TilgangRequest.kt
@@ -6,7 +6,7 @@ sealed interface TilgangRequest
 
 data class SakTilgangRequest(
     val saksnummer: String,
-    val påkrevdRolle: Rolle? = null,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val operasjon: Operasjon,
     /**
      * Valgfritt felt for å spesifisere relevante identer knyttet til saken.
@@ -18,7 +18,7 @@ data class SakTilgangRequest(
 data class BehandlingTilgangRequest(
     val behandlingsreferanse: UUID,
     val avklaringsbehovKode: String?,
-    val påkrevdRolle: Rolle? = null,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val operasjon: Operasjon,
     /**
      * Valgfritt felt for å spesifisere relevante identer knyttet til saken.
@@ -31,7 +31,7 @@ data class BehandlingTilgangRequest(
 data class JournalpostTilgangRequest(
     val journalpostId: Long,
     val avklaringsbehovKode: String?,
-    val påkrevdRolle: Rolle? = null,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val operasjon: Operasjon
 ) : TilgangRequest
 
@@ -42,12 +42,17 @@ data class PersonTilgangRequest(
 data class TilbakekrevingTilgangRequest(
     val saksnummer: String,
     val behandlingsreferanse: UUID,
+    @Deprecated("Trengs for bakoverkompabilitet da denne allerede er i bruk")
     val påkrevdRolle: Rolle? = null,
+    val påkrevdRoller: List<Rolle> = emptyList(),
     val operasjon: Operasjon,
 ) : TilgangRequest {
+    val effektivePåkrevdRoller: List<Rolle>
+        get() = påkrevdRoller.ifEmpty { listOfNotNull(påkrevdRolle) }
+
     init {
         if (operasjon == Operasjon.SAKSBEHANDLE) {
-            require(påkrevdRolle != null) { "Påkrevd rolle må være satt for operasjon SAKSBEHANDLE" }
+            require(effektivePåkrevdRoller.isNotEmpty()) { "Påkrevd rolle må være satt for operasjon SAKSBEHANDLE" }
         }
     }
 }

--- a/app/main/kotlin/tilgang/TilgangService.kt
+++ b/app/main/kotlin/tilgang/TilgangService.kt
@@ -163,7 +163,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = req.påkrevdRolle,
+            påkrevdRolle = req.effektivePåkrevdRoller,
             operasjoner = listOf(req.operasjon)
         )
         return regelService.vurderTilgang(regelInput)[req.operasjon] == true

--- a/app/main/kotlin/tilgang/TilgangService.kt
+++ b/app/main/kotlin/tilgang/TilgangService.kt
@@ -47,7 +47,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = null, 
-            påkrevdRolle = req.påkrevdRolle,
+            påkrevdRolle = req.påkrevdRolle ?: emptyList(),
             operasjoner = listOf(req.operasjon)
         )
         return regelService.vurderTilgang(regelInput)[req.operasjon] == true
@@ -75,7 +75,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = avklaringsbehov,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = req.påkrevdRolle,
+            påkrevdRolle = req.påkrevdRolle ?: emptyList(),
             operasjoner = (req.operasjonerIKontekst + req.operasjon).toSet().toList()
         )
         return regelService.vurderTilgang(regelInput)
@@ -109,7 +109,7 @@ class TilgangService(
             søkerIdenter = identer,
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = avklaringsbehov,
-            påkrevdRolle = req.påkrevdRolle,
+            påkrevdRolle = req.påkrevdRolle ?: emptyList(),
             operasjoner = listOf(req.operasjon),
         )
         return regelService.vurderTilgang(regelInput)[req.operasjon] == true

--- a/app/main/kotlin/tilgang/regler/AvklaringsbehovRolleRegel.kt
+++ b/app/main/kotlin/tilgang/regler/AvklaringsbehovRolleRegel.kt
@@ -14,8 +14,8 @@ data object AvklaringsbehovRolleRegel : Regel<AvklaringsbehovRolleInput> {
         if (input.avklaringsbehovFraPostmottak != null) {
             sjekker.add(kanAvklareBehov(input.avklaringsbehovFraPostmottak, input.roller))
         }
-        if (input.påkrevdRolle != null) {
-            sjekker.add(input.roller.contains(input.påkrevdRolle))
+        if (input.påkrevdRolle.isNotEmpty()) {
+            sjekker.add(input.påkrevdRolle.any { it in input.roller })
         }
 
         require(sjekker.isNotEmpty()) { "Avklaringsbehov eller påkrevd rolle må være satt" }
@@ -34,7 +34,7 @@ data object AvklaringsbehovRolleRegel : Regel<AvklaringsbehovRolleInput> {
 data class AvklaringsbehovRolleInput(
     val avklaringsbehovFraBehandlingsflyt: Definisjon? = null,
     val avklaringsbehovFraPostmottak: PostmottakDefinisjon?,
-    val påkrevdRolle: Rolle?,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val roller: List<Rolle>
 )
 

--- a/app/main/kotlin/tilgang/regler/Regelnput.kt
+++ b/app/main/kotlin/tilgang/regler/Regelnput.kt
@@ -15,7 +15,7 @@ class RegelInput (
     val søkerIdenter: RelevanteIdenter,
     val avklaringsbehovFraBehandlingsflyt: Definisjon?,
     val avklaringsbehovFraPostmottak: PostmottakDefinisjon?,
-    val påkrevdRolle: Rolle?,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val operasjoner: List<Operasjon>,
 )
 

--- a/app/main/kotlin/tilgang/routes/TilgangRoute.kt
+++ b/app/main/kotlin/tilgang/routes/TilgangRoute.kt
@@ -68,7 +68,7 @@ fun NormalOpenAPIRoute.tilgang(
             post<Unit, TilgangResponse, JournalpostTilgangRequest> { _, req ->
                 prometheus.httpCallCounter(pipeline.call).increment()
 
-                if (req.operasjon == Operasjon.SAKSBEHANDLE && req.avklaringsbehovKode == null && req.påkrevdRolle.isEmpty()) {
+                if (req.operasjon == Operasjon.SAKSBEHANDLE && req.avklaringsbehovKode == null && req.påkrevdRolle.isNullOrEmpty()) {
                     log.info("Kan ikke saksbehandle uten avklaringsbehov eller påkrevd rolle $req")
                     respondWithStatus(HttpStatusCode.BadRequest)
                 }

--- a/app/main/kotlin/tilgang/routes/TilgangRoute.kt
+++ b/app/main/kotlin/tilgang/routes/TilgangRoute.kt
@@ -68,7 +68,7 @@ fun NormalOpenAPIRoute.tilgang(
             post<Unit, TilgangResponse, JournalpostTilgangRequest> { _, req ->
                 prometheus.httpCallCounter(pipeline.call).increment()
 
-                if (req.operasjon == Operasjon.SAKSBEHANDLE && req.avklaringsbehovKode == null && req.påkrevdRolle == null) {
+                if (req.operasjon == Operasjon.SAKSBEHANDLE && req.avklaringsbehovKode == null && req.påkrevdRolle.isEmpty()) {
                     log.info("Kan ikke saksbehandle uten avklaringsbehov eller påkrevd rolle $req")
                     respondWithStatus(HttpStatusCode.BadRequest)
                 }

--- a/app/test/kotlin/tilgang/TilgangRequestBakoverkompatibilitetTest.kt
+++ b/app/test/kotlin/tilgang/TilgangRequestBakoverkompatibilitetTest.kt
@@ -1,0 +1,461 @@
+package tilgang
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+import no.nav.aap.tilgang.BehandlingTilgangRequest
+import no.nav.aap.tilgang.JournalpostTilgangRequest
+import no.nav.aap.tilgang.Operasjon
+import no.nav.aap.tilgang.PersonTilgangRequest
+import no.nav.aap.tilgang.Rolle
+import no.nav.aap.tilgang.SakTilgangRequest
+import no.nav.aap.tilgang.TilbakekrevingTilgangRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Tester at JSON-kontrakten for TilgangRequest-klassene er bakoverkompatibel.
+ *
+ * Disse testene sikrer at:
+ * - Gamle klienter som sender minimale JSON-payloads fortsatt fungerer
+ * - Ukjente felter i JSON ignoreres (framoverkompatibilitet)
+ * - Defaultverdier settes korrekt når valgfrie felter utelates
+ */
+class TilgangRequestBakoverkompatibilitetTest {
+
+    private val objectMapper = DefaultJsonMapper.objectMapper()
+
+    // --- SakTilgangRequest ---
+
+    @Test
+    fun `SakTilgangRequest - minimal JSON med påkrevetRolle satt til null`() {
+        val json = """
+            {
+                "saksnummer": "12345",
+                "påkrevdRolle": null,
+                "operasjon": "SE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<SakTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+        assertThat(request.operasjon).isEqualTo(Operasjon.SE)
+        assertThat(request.påkrevdRolle).isNull()
+        assertThat(request.relevanteIdenter).isNull()
+    }
+
+    @Test
+    fun `SakTilgangRequest - minimal JSON uten valgfrie felter`() {
+        val json = """
+            {
+                "saksnummer": "12345",
+                "operasjon": "SE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<SakTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+        assertThat(request.operasjon).isEqualTo(Operasjon.SE)
+        assertThat(request.påkrevdRolle).isNull()
+        assertThat(request.relevanteIdenter).isNull()
+    }
+
+    @Test
+    fun `SakTilgangRequest - komplett JSON med alle felter`() {
+        val json = """
+            {
+                "saksnummer": "12345",
+                "påkrevdRolle": ["SAKSBEHANDLER_OPPFOLGING"],
+                "operasjon": "SAKSBEHANDLE",
+                "relevanteIdenter": {
+                    "søker": ["12345678901"],
+                    "barn": ["09876543210"]
+                }
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<SakTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+        assertThat(request.operasjon).isEqualTo(Operasjon.SAKSBEHANDLE)
+        assertThat(request.påkrevdRolle).containsExactly(Rolle.SAKSBEHANDLER_OPPFOLGING)
+        assertThat(request.relevanteIdenter).isNotNull
+        assertThat(request.relevanteIdenter!!.søker).containsExactly("12345678901")
+        assertThat(request.relevanteIdenter!!.barn).containsExactly("09876543210")
+    }
+
+    @Test
+    fun `SakTilgangRequest - ukjente felter ignoreres`() {
+        val json = """
+            {
+                "saksnummer": "12345",
+                "operasjon": "SE",
+                "ukjentFelt": "verdi",
+                "annetUkjentFelt": 42
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<SakTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+        assertThat(request.operasjon).isEqualTo(Operasjon.SE)
+    }
+
+    // --- BehandlingTilgangRequest ---
+
+    @Test
+    fun `BehandlingTilgangRequest - minimal JSON uten valgfrie felter`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "behandlingsreferanse": "$uuid",
+                "avklaringsbehovKode": null,
+                "operasjon": "SE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<BehandlingTilgangRequest>(json)
+
+        assertThat(request.behandlingsreferanse).isEqualTo(uuid)
+        assertThat(request.avklaringsbehovKode).isNull()
+        assertThat(request.operasjon).isEqualTo(Operasjon.SE)
+        assertThat(request.påkrevdRolle).isNull()
+        assertThat(request.relevanteIdenter).isNull()
+        assertThat(request.operasjonerIKontekst).isEmpty()
+    }
+
+    @Test
+    fun `BehandlingTilgangRequest - komplett JSON med alle felter`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "behandlingsreferanse": "$uuid",
+                "avklaringsbehovKode": "5003",
+                "påkrevdRolle": ["SAKSBEHANDLER_OPPFOLGING", "KVALITETSSIKRER"],
+                "operasjon": "SAKSBEHANDLE",
+                "relevanteIdenter": {
+                    "søker": ["12345678901"],
+                    "barn": []
+                },
+                "operasjonerIKontekst": ["SE", "SAKSBEHANDLE"]
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<BehandlingTilgangRequest>(json)
+
+        assertThat(request.behandlingsreferanse).isEqualTo(uuid)
+        assertThat(request.avklaringsbehovKode).isEqualTo("5003")
+        assertThat(request.påkrevdRolle).containsExactly(Rolle.SAKSBEHANDLER_OPPFOLGING, Rolle.KVALITETSSIKRER)
+        assertThat(request.operasjon).isEqualTo(Operasjon.SAKSBEHANDLE)
+        assertThat(request.relevanteIdenter).isNotNull
+        assertThat(request.operasjonerIKontekst).containsExactly(Operasjon.SE, Operasjon.SAKSBEHANDLE)
+    }
+
+    @Test
+    fun `BehandlingTilgangRequest - uten operasjonerIKontekst bruker default tom liste`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "behandlingsreferanse": "$uuid",
+                "avklaringsbehovKode": "5003",
+                "operasjon": "SE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<BehandlingTilgangRequest>(json)
+
+        assertThat(request.operasjonerIKontekst).isEmpty()
+    }
+
+    @Test
+    fun `BehandlingTilgangRequest - ukjente felter ignoreres`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "behandlingsreferanse": "$uuid",
+                "avklaringsbehovKode": null,
+                "operasjon": "SE",
+                "nyttFremtidigFelt": true
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<BehandlingTilgangRequest>(json)
+
+        assertThat(request.behandlingsreferanse).isEqualTo(uuid)
+    }
+
+    // --- JournalpostTilgangRequest ---
+
+    @Test
+    fun `JournalpostTilgangRequest - minimal JSON uten valgfrie felter`() {
+        val json = """
+            {
+                "journalpostId": 123456789,
+                "avklaringsbehovKode": null,
+                "operasjon": "SE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<JournalpostTilgangRequest>(json)
+
+        assertThat(request.journalpostId).isEqualTo(123456789L)
+        assertThat(request.avklaringsbehovKode).isNull()
+        assertThat(request.operasjon).isEqualTo(Operasjon.SE)
+        assertThat(request.påkrevdRolle).isNull()
+    }
+
+    @Test
+    fun `JournalpostTilgangRequest - komplett JSON med alle felter`() {
+        val json = """
+            {
+                "journalpostId": 123456789,
+                "avklaringsbehovKode": "5001",
+                "påkrevdRolle": ["BESLUTTER"],
+                "operasjon": "SAKSBEHANDLE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<JournalpostTilgangRequest>(json)
+
+        assertThat(request.journalpostId).isEqualTo(123456789L)
+        assertThat(request.avklaringsbehovKode).isEqualTo("5001")
+        assertThat(request.påkrevdRolle).containsExactly(Rolle.BESLUTTER)
+        assertThat(request.operasjon).isEqualTo(Operasjon.SAKSBEHANDLE)
+    }
+
+    @Test
+    fun `JournalpostTilgangRequest - ukjente felter ignoreres`() {
+        val json = """
+            {
+                "journalpostId": 123456789,
+                "avklaringsbehovKode": null,
+                "operasjon": "SE",
+                "ukjentFelt": [1, 2, 3]
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<JournalpostTilgangRequest>(json)
+
+        assertThat(request.journalpostId).isEqualTo(123456789L)
+    }
+
+    // --- PersonTilgangRequest ---
+
+    @Test
+    fun `PersonTilgangRequest - deserialisering av enkel request`() {
+        val json = """
+            {
+                "personIdent": "12345678901"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<PersonTilgangRequest>(json)
+
+        assertThat(request.personIdent).isEqualTo("12345678901")
+    }
+
+    @Test
+    fun `PersonTilgangRequest - ukjente felter ignoreres`() {
+        val json = """
+            {
+                "personIdent": "12345678901",
+                "ukjentFelt": "verdi"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<PersonTilgangRequest>(json)
+
+        assertThat(request.personIdent).isEqualTo("12345678901")
+    }
+
+    // --- TilbakekrevingTilgangRequest ---
+
+    @Test
+    fun `TilbakekrevingTilgangRequest - med kun gammel påkrevdRolle-felt (bakoverkompatibilitet)`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "saksnummer": "12345",
+                "behandlingsreferanse": "$uuid",
+                "påkrevdRolle": "SAKSBEHANDLER_OPPFOLGING",
+                "operasjon": "SAKSBEHANDLE"
+            }
+        """.trimIndent()
+
+        @Suppress("DEPRECATION")
+        val request = objectMapper.readValue<TilbakekrevingTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+        assertThat(request.behandlingsreferanse).isEqualTo(uuid)
+        @Suppress("DEPRECATION")
+        assertThat(request.påkrevdRolle).isEqualTo(Rolle.SAKSBEHANDLER_OPPFOLGING)
+        assertThat(request.påkrevdRoller).isNull()
+        assertThat(request.operasjon).isEqualTo(Operasjon.SAKSBEHANDLE)
+        assertThat(request.effektivePåkrevdRoller).containsExactly(Rolle.SAKSBEHANDLER_OPPFOLGING)
+    }
+
+    @Test
+    fun `TilbakekrevingTilgangRequest - med nytt påkrevdRoller-felt`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "saksnummer": "12345",
+                "behandlingsreferanse": "$uuid",
+                "påkrevdRoller": ["SAKSBEHANDLER_OPPFOLGING", "KVALITETSSIKRER"],
+                "operasjon": "SAKSBEHANDLE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<TilbakekrevingTilgangRequest>(json)
+
+        assertThat(request.påkrevdRoller).containsExactly(Rolle.SAKSBEHANDLER_OPPFOLGING, Rolle.KVALITETSSIKRER)
+        @Suppress("DEPRECATION")
+        assertThat(request.påkrevdRolle).isNull()
+        assertThat(request.effektivePåkrevdRoller).containsExactly(Rolle.SAKSBEHANDLER_OPPFOLGING, Rolle.KVALITETSSIKRER)
+    }
+
+    @Test
+    fun `TilbakekrevingTilgangRequest - med begge påkrevdRolle-feltene prioriterer påkrevdRoller`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "saksnummer": "12345",
+                "behandlingsreferanse": "$uuid",
+                "påkrevdRolle": "SAKSBEHANDLER_OPPFOLGING",
+                "påkrevdRoller": ["KVALITETSSIKRER"],
+                "operasjon": "SAKSBEHANDLE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<TilbakekrevingTilgangRequest>(json)
+
+        assertThat(request.effektivePåkrevdRoller).containsExactly(Rolle.KVALITETSSIKRER)
+    }
+
+    @Test
+    fun `TilbakekrevingTilgangRequest - minimal JSON for SE-operasjon`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "saksnummer": "12345",
+                "behandlingsreferanse": "$uuid",
+                "operasjon": "SE"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<TilbakekrevingTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+        assertThat(request.operasjon).isEqualTo(Operasjon.SE)
+        assertThat(request.effektivePåkrevdRoller).isEmpty()
+    }
+
+    @Test
+    fun `TilbakekrevingTilgangRequest - ukjente felter ignoreres`() {
+        val uuid = UUID.randomUUID()
+        val json = """
+            {
+                "saksnummer": "12345",
+                "behandlingsreferanse": "$uuid",
+                "operasjon": "SE",
+                "nyttFelt": "ukjent"
+            }
+        """.trimIndent()
+
+        val request = objectMapper.readValue<TilbakekrevingTilgangRequest>(json)
+
+        assertThat(request.saksnummer).isEqualTo("12345")
+    }
+
+    // --- Serialisering/deserialisering roundtrip ---
+
+    @Test
+    fun `SakTilgangRequest - serialisering og deserialisering gir samme objekt`() {
+        val original = SakTilgangRequest(
+            saksnummer = "12345",
+            påkrevdRolle = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING),
+            operasjon = Operasjon.SAKSBEHANDLE,
+        )
+
+        val json = objectMapper.writeValueAsString(original)
+        val deserialisert = objectMapper.readValue<SakTilgangRequest>(json)
+
+        assertThat(deserialisert).isEqualTo(original)
+    }
+
+    @Test
+    fun `BehandlingTilgangRequest - serialisering og deserialisering gir samme objekt`() {
+        val original = BehandlingTilgangRequest(
+            behandlingsreferanse = UUID.randomUUID(),
+            avklaringsbehovKode = "5003",
+            påkrevdRolle = listOf(Rolle.KVALITETSSIKRER),
+            operasjon = Operasjon.SAKSBEHANDLE,
+            operasjonerIKontekst = listOf(Operasjon.SE),
+        )
+
+        val json = objectMapper.writeValueAsString(original)
+        val deserialisert = objectMapper.readValue<BehandlingTilgangRequest>(json)
+
+        assertThat(deserialisert).isEqualTo(original)
+    }
+
+    @Test
+    fun `JournalpostTilgangRequest - serialisering og deserialisering gir samme objekt`() {
+        val original = JournalpostTilgangRequest(
+            journalpostId = 123456789L,
+            avklaringsbehovKode = "5001",
+            påkrevdRolle = listOf(Rolle.BESLUTTER),
+            operasjon = Operasjon.SAKSBEHANDLE,
+        )
+
+        val json = objectMapper.writeValueAsString(original)
+        val deserialisert = objectMapper.readValue<JournalpostTilgangRequest>(json)
+
+        assertThat(deserialisert).isEqualTo(original)
+    }
+
+    @Test
+    fun `PersonTilgangRequest - serialisering og deserialisering gir samme objekt`() {
+        val original = PersonTilgangRequest(personIdent = "12345678901")
+
+        val json = objectMapper.writeValueAsString(original)
+        val deserialisert = objectMapper.readValue<PersonTilgangRequest>(json)
+
+        assertThat(deserialisert).isEqualTo(original)
+    }
+
+    @Test
+    fun `alle Operasjon-verdier kan deserialiseres`() {
+        Operasjon.entries.forEach { operasjon ->
+            val json = """
+                {
+                    "saksnummer": "12345",
+                    "operasjon": "${operasjon.name}"
+                }
+            """.trimIndent()
+
+            val request = objectMapper.readValue<SakTilgangRequest>(json)
+
+            assertThat(request.operasjon).isEqualTo(operasjon)
+        }
+    }
+
+    @Test
+    fun `alle Rolle-verdier kan deserialiseres`() {
+        Rolle.entries.forEach { rolle ->
+            val json = """
+                {
+                    "saksnummer": "12345",
+                    "påkrevdRolle": ["${rolle.name}"],
+                    "operasjon": "SE"
+                }
+            """.trimIndent()
+
+            val request = objectMapper.readValue<SakTilgangRequest>(json)
+
+            assertThat(request.påkrevdRolle).containsExactly(rolle)
+        }
+    }
+}

--- a/app/test/kotlin/tilgang/regler/AvklaringsbehovRolleRegelTest.kt
+++ b/app/test/kotlin/tilgang/regler/AvklaringsbehovRolleRegelTest.kt
@@ -13,7 +13,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = null,
+            påkrevdRolle = emptyList(),
             roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
         )
         assertTrue(AvklaringsbehovRolleRegel.vurder(input))
@@ -24,7 +24,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = null,
+            påkrevdRolle = emptyList(),
             roller = listOf(Rolle.BESLUTTER)
         )
         assertFalse(AvklaringsbehovRolleRegel.vurder(input))
@@ -35,7 +35,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = Rolle.BESLUTTER,
+            påkrevdRolle = listOf(Rolle.BESLUTTER),
             roller = listOf(Rolle.BESLUTTER)
         )
         assertTrue(AvklaringsbehovRolleRegel.vurder(input))
@@ -46,7 +46,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = Rolle.BESLUTTER,
+            påkrevdRolle = listOf(Rolle.BESLUTTER),
             roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
         )
         assertFalse(AvklaringsbehovRolleRegel.vurder(input))
@@ -58,7 +58,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = Rolle.BESLUTTER,
+            påkrevdRolle = listOf(Rolle.BESLUTTER),
             roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING, Rolle.BESLUTTER)
         )
         assertTrue(AvklaringsbehovRolleRegel.vurder(input))
@@ -69,7 +69,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = Rolle.BESLUTTER,
+            påkrevdRolle = listOf(Rolle.BESLUTTER),
             roller = listOf(Rolle.SAKSBEHANDLER_OPPFOLGING)
         )
         assertFalse(AvklaringsbehovRolleRegel.vurder(input))
@@ -80,7 +80,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = Definisjon.MANUELT_SATT_PÅ_VENT,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = Rolle.BESLUTTER,
+            påkrevdRolle = listOf(Rolle.BESLUTTER),
             roller = listOf(Rolle.BESLUTTER)
         )
         assertFalse(AvklaringsbehovRolleRegel.vurder(input))
@@ -91,7 +91,7 @@ class AvklaringsbehovRolleRegelTest {
         val input = AvklaringsbehovRolleInput(
             avklaringsbehovFraBehandlingsflyt = null,
             avklaringsbehovFraPostmottak = null,
-            påkrevdRolle = null,
+            påkrevdRolle = emptyList(),
             roller = listOf(Rolle.BESLUTTER)
         )
         assertThrows<IllegalArgumentException> {

--- a/app/test/kotlin/tilgang/regler/RegelServiceTest.kt
+++ b/app/test/kotlin/tilgang/regler/RegelServiceTest.kt
@@ -99,7 +99,7 @@ class RegelServiceTest {
                 currentToken = OidcToken(token),
                 søkerIdenter = RelevanteIdenter(søker = listOf("423"), barn = listOf()),
                 operasjoner = listOf(Operasjon.SAKSBEHANDLE),
-                påkrevdRolle = null,
+                påkrevdRolle = emptyList(),
                 roller = listOf()
             )
         )

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationBodyPathConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationBodyPathConfig.kt
@@ -12,7 +12,7 @@ data class AuthorizationBodyPathConfig(
     val operasjon: Operasjon,
     val applicationRole: String? = null,
     val applicationsOnly: Boolean = false,
-    val påkrevdRolle: Rolle? = null,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val relevanteIdenterResolver: RelevanteIdenterResolver? = null,
     val journalpostIdResolver: JournalpostIdResolver = DefaultJournalpostIdResolver(),
     val behandlingreferanseResolver: BehandlingreferanseResolver = DefaultBehandlingreferanseResolver()

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationParamPathConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationParamPathConfig.kt
@@ -13,7 +13,7 @@ data class AuthorizationParamPathConfig(
     val operasjon: Operasjon = Operasjon.SE,
     val operasjonerIKontekst: List<Operasjon> = emptyList(),
     val avklaringsbehovKode: String? = null,
-    val påkrevdRolle: Rolle? = null,
+    val påkrevdRolle: List<Rolle> = emptyList(),
     val applicationRole: String? = null,
     val applicationsOnly: Boolean = false,
     val sakPathParam: SakPathParam? = null,
@@ -22,7 +22,7 @@ data class AuthorizationParamPathConfig(
     val journalpostPathParam: JournalpostPathParam? = null,
 ) : AuthorizationRouteConfig {
     init {
-        require(operasjon != Operasjon.SAKSBEHANDLE || avklaringsbehovKode != null || påkrevdRolle != null) {
+        require(operasjon != Operasjon.SAKSBEHANDLE || avklaringsbehovKode != null || påkrevdRolle.isNotEmpty()) {
             "Avklaringsbehovkode eller påkrevdRolle må være satt for operasjon SAKSBEHANDLE"
         }
         if (applicationsOnly) {

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -197,7 +197,7 @@ fun Application.autorisertEksempelApp() {
                         authorizedGet<TestReferanse, Saksinfo>(
                             AuthorizationParamPathConfig(
                                 operasjon = Operasjon.SAKSBEHANDLE,
-                                påkrevdRolle = Rolle.BESLUTTER,
+                                påkrevdRolle = listOf(Rolle.BESLUTTER),
                                 sakPathParam = SakPathParam("saksnummer")
                             ),
                         ) { req ->
@@ -208,7 +208,7 @@ fun Application.autorisertEksempelApp() {
                         authorizedPost<Unit, Saksinfo, Saksinfo>(
                             AuthorizationBodyPathConfig(
                                 operasjon = Operasjon.SAKSBEHANDLE,
-                                påkrevdRolle = Rolle.BESLUTTER,
+                                påkrevdRolle = listOf(Rolle.BESLUTTER),
                             )
                         ) { _, dto ->
                             respond(dto)

--- a/plugin/src/test/kotlin/TilgangPluginTest.kt
+++ b/plugin/src/test/kotlin/TilgangPluginTest.kt
@@ -546,7 +546,7 @@ class TilgangPluginTest {
         )
 
         assertThat(res?.saksnummer).isEqualTo(randomUuid)
-        assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(Rolle.BESLUTTER)
+        assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(listOf(Rolle.BESLUTTER))
     }
 
     @Test
@@ -572,7 +572,7 @@ class TilgangPluginTest {
         )
 
         assertThat(res?.saksnummer).isEqualTo(randomUuid)
-        assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(Rolle.BESLUTTER)
+        assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(listOf(Rolle.BESLUTTER))
     }
 
     @Test


### PR DESCRIPTION
Endrer til å støtte liste med påkrevde roller. Disse er nullable. 

Det er kun tilbakekreving som er i bruk i produksjon. 