### PR TITLE
AAP-2194 Mulighet for autorisere azp

### DIFF
--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/ApplicationCallExtensions.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/ApplicationCallExtensions.kt
@@ -10,3 +10,7 @@ fun ApplicationCall.ident(): String {
     }.getClaim("NAVident", String::class)
         ?: error("Ident mangler i token claims")
 }
+
+inline fun <reified T : Any> ApplicationCall.getClaimOrNull(claim: String): T? {
+    return principal<JWTPrincipal>()?.getClaim(claim, T::class)
+}

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationBodyPathConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationBodyPathConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.tilgang
 
+import java.util.UUID
 import no.nav.aap.tilgang.plugin.kontrakt.BehandlingreferanseResolver
 import no.nav.aap.tilgang.plugin.kontrakt.Behandlingsreferanse
 import no.nav.aap.tilgang.plugin.kontrakt.JournalpostIdResolver
@@ -11,12 +12,29 @@ import no.nav.aap.tilgang.plugin.kontrakt.Saksreferanse
 data class AuthorizationBodyPathConfig(
     val operasjon: Operasjon,
     val applicationRole: String? = null,
+    val authorizedAzps: List<UUID>? = null,
     val applicationsOnly: Boolean = false,
     val påkrevdRolle: List<Rolle> = emptyList(),
     val relevanteIdenterResolver: RelevanteIdenterResolver? = null,
     val journalpostIdResolver: JournalpostIdResolver = DefaultJournalpostIdResolver(),
     val behandlingreferanseResolver: BehandlingreferanseResolver = DefaultBehandlingreferanseResolver()
 ) : AuthorizationRouteConfig {
+
+    init {
+        val hasApplicationRole = applicationRole != null
+        val hasAuthorizedAzps = authorizedAzps != null
+
+        require(!(hasApplicationRole && hasAuthorizedAzps)) {
+            "Kan ikke sette både applicationRole og authorizedAzps"
+        }
+
+        if (applicationsOnly) {
+            require(hasApplicationRole || hasAuthorizedAzps) {
+                "applicationRole eller authorizedAzps må være satt dersom applicationsOnly = true"
+            }
+        }
+    }
+
     suspend fun tilTilgangRequest(request: Any): AuthorizedRequest {
         when (request) {
             is Saksreferanse -> {
@@ -25,6 +43,7 @@ data class AuthorizationBodyPathConfig(
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
+                    authorizedAzps,
                     SakTilgangRequest(
                         saksnummer = referanse,
                         påkrevdRolle = påkrevdRolle,
@@ -39,6 +58,7 @@ data class AuthorizationBodyPathConfig(
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
+                    authorizedAzps,
                     PersonTilgangRequest(referanse)
                 )
             }
@@ -49,10 +69,11 @@ data class AuthorizationBodyPathConfig(
                 val påkrevdeRoller = påkrevdRolle.ifEmpty {
                     request.hentPåkrevdRolle()
                 }
-                
+
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
+                    authorizedAzps,
                     BehandlingTilgangRequest(
                         behandlingsreferanse = referanse,
                         påkrevdRolle = påkrevdeRoller,
@@ -72,6 +93,7 @@ data class AuthorizationBodyPathConfig(
                 return AuthorizedRequest(
                     applicationsOnly,
                     applicationRole,
+                    authorizedAzps,
                     JournalpostTilgangRequest(
                         journalpostId = referanse,
                         påkrevdRolle = påkrevdeRoller,
@@ -83,6 +105,7 @@ data class AuthorizationBodyPathConfig(
             else -> return AuthorizedRequest(
                 applicationsOnly = applicationsOnly,
                 applicationRole = applicationRole,
+                authorizedAzps = authorizedAzps,
                 tilgangRequest = null
             )
         }

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationParamPathConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationParamPathConfig.kt
@@ -2,6 +2,7 @@ package no.nav.aap.tilgang
 
 import io.ktor.http.Parameters
 import io.ktor.server.util.getOrFail
+import java.util.UUID
 import no.nav.aap.tilgang.plugin.kontrakt.RelevanteIdenterResolver
 
 /**
@@ -14,6 +15,7 @@ data class AuthorizationParamPathConfig(
     val operasjonerIKontekst: List<Operasjon> = emptyList(),
     val avklaringsbehovKode: String? = null,
     val påkrevdRolle: List<Rolle> = emptyList(),
+    val authorizedAzps: List<UUID>? = null,
     val applicationRole: String? = null,
     val applicationsOnly: Boolean = false,
     val sakPathParam: SakPathParam? = null,
@@ -25,9 +27,16 @@ data class AuthorizationParamPathConfig(
         require(operasjon != Operasjon.SAKSBEHANDLE || avklaringsbehovKode != null || påkrevdRolle.isNotEmpty()) {
             "Avklaringsbehovkode eller påkrevdRolle må være satt for operasjon SAKSBEHANDLE"
         }
+        val hasApplicationRole = applicationRole != null
+        val hasAuthorizedAzps = authorizedAzps != null
+
+        require(!(hasApplicationRole && hasAuthorizedAzps)) {
+            "Kan ikke sette både applicationRole og authorizedAzps"
+        }
+
         if (applicationsOnly) {
-            requireNotNull(applicationRole) {
-                "applicationRole må være satt dersom applicationsOnly = true"
+            require(hasApplicationRole || hasAuthorizedAzps) {
+                "applicationRole eller authorizedAzps må være satt dersom applicationsOnly = true"
             }
         }
     }
@@ -39,6 +48,7 @@ data class AuthorizationParamPathConfig(
             return AuthorizedRequest(
                 applicationsOnly,
                 applicationRole,
+                authorizedAzps,
                 SakTilgangRequest(
                     relevanteIdenter = relevanteIdenter,
                     saksnummer = saksnummer,
@@ -53,6 +63,7 @@ data class AuthorizationParamPathConfig(
             return AuthorizedRequest(
                 applicationsOnly,
                 applicationRole,
+                authorizedAzps,
                 BehandlingTilgangRequest(
                     relevanteIdenter = relevanteIdenter,
                     behandlingsreferanse = behandlingsreferanse,
@@ -69,6 +80,7 @@ data class AuthorizationParamPathConfig(
             return AuthorizedRequest(
                 applicationsOnly,
                 applicationRole,
+                authorizedAzps,
                 JournalpostTilgangRequest(
                     journalpostId = journalpostId,
                     operasjon = operasjon,
@@ -81,6 +93,7 @@ data class AuthorizationParamPathConfig(
         return AuthorizedRequest(
             applicationsOnly = applicationsOnly,
             applicationRole = applicationRole,
+            authorizedAzps = authorizedAzps,
             tilgangRequest = null
         )
     }

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationRouteConfig.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/AuthorizationRouteConfig.kt
@@ -1,10 +1,13 @@
 package no.nav.aap.tilgang
 
+import java.util.UUID
+
 interface AuthorizationRouteConfig
 
 
 data class AuthorizedRequest(
     val applicationsOnly: Boolean,
     val applicationRole: String?,
+    val authorizedAzps: List<UUID>?,
     val tilgangRequest: TilgangRequest?
 )

--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangService.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangService.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.tilgang
 
 import io.ktor.server.application.ApplicationCall
+import java.util.UUID
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 
 object TilgangService {
@@ -9,12 +10,22 @@ object TilgangService {
         call: ApplicationCall,
         token: OidcToken
     ): TilgangResponse {
+
+        val azp = call.getClaimOrNull<UUID>("azp")
+        val isAuthorizedAzp = azp != null &&
+                authorizedRequest.authorizedAzps != null &&
+                authorizedRequest.authorizedAzps.contains(azp)
+
         if (token.isClientCredentials()) {
-            return TilgangResponse(
-                authorizedRequest.applicationRole != null &&
-                        call.rolesClaim().contains(authorizedRequest.applicationRole)
-            )
+            val isAuthorizedRole = authorizedRequest.applicationRole != null &&
+                    call.rolesClaim().contains(authorizedRequest.applicationRole)
+            return TilgangResponse(isAuthorizedAzp || isAuthorizedRole)
         }
+
+        if (authorizedRequest.authorizedAzps != null && !isAuthorizedAzp) {
+            return TilgangResponse(false)
+        }
+
         if (authorizedRequest.applicationsOnly) {
             return TilgangResponse(false)
         }

--- a/plugin/src/test/kotlin/AuthorizationRouteConfigValidationTest.kt
+++ b/plugin/src/test/kotlin/AuthorizationRouteConfigValidationTest.kt
@@ -1,0 +1,35 @@
+import java.util.UUID
+import no.nav.aap.tilgang.AuthorizationBodyPathConfig
+import no.nav.aap.tilgang.AuthorizationParamPathConfig
+import no.nav.aap.tilgang.Operasjon
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AuthorizationRouteConfigValidationTest {
+
+    @Test
+    fun `AuthorizationBodyPathConfig feiler når både applicationRole og authorizedAzps er satt`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            AuthorizationBodyPathConfig(
+                operasjon = Operasjon.SE,
+                applicationRole = "tilgang-rolle",
+                authorizedAzps = listOf(UUID.randomUUID())
+            )
+        }
+
+        assertEquals("Kan ikke sette både applicationRole og authorizedAzps", exception.message)
+    }
+
+    @Test
+    fun `AuthorizationParamPathConfig feiler når både applicationRole og authorizedAzps er satt`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            AuthorizationParamPathConfig(
+                applicationRole = "tilgang-rolle",
+                authorizedAzps = listOf(UUID.randomUUID())
+            )
+        }
+
+        assertEquals("Kan ikke sette både applicationRole og authorizedAzps", exception.message)
+    }
+}

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -45,6 +45,7 @@ import no.nav.aap.tilgang.plugin.kontrakt.Personreferanse
 import no.nav.aap.tilgang.plugin.kontrakt.Saksreferanse
 
 val enAnnenReferanseTilbehandlingReferanse = mutableMapOf<String, UUID>()
+val AUTHORIZED_AZP: UUID = UUID.randomUUID()
 
 fun Application.autorisertEksempelApp() {
     commonKtorModule(PrometheusMeterRegistry(PrometheusConfig.DEFAULT), InfoModel(), IdentityProvider.ENTRA_ID)
@@ -231,6 +232,16 @@ fun Application.autorisertEksempelApp() {
                             respond(Saksinfo(saksnummer = req.saksnummer))
                         }
                     }
+                    route("authorized-azps-param") {
+                        authorizedGet<TestReferanse, Saksinfo>(
+                            AuthorizationParamPathConfig(
+                                sakPathParam = SakPathParam("saksnummer"),
+                                authorizedAzps = listOf(AUTHORIZED_AZP)
+                            )
+                        ) { req ->
+                            respond(Saksinfo(saksnummer = req.saksnummer))
+                        }
+                    }
                 }
                 route("testApi/paakrevdRolle") {
                     route("sak/{saksnummer}") {
@@ -305,6 +316,16 @@ fun Application.autorisertEksempelApp() {
                                 brukerIdentResolver = TestResolver()
                             ),
                             modules = arrayOf(TagModule(listOf(Tags.Tilgangkontrollert)))
+                        ) { _, dto ->
+                            respond(dto)
+                        }
+                    }
+                    route("authorized-azps-body") {
+                        authorizedPost<Unit, Saksinfo, Saksinfo>(
+                            AuthorizationBodyPathConfig(
+                                operasjon = Operasjon.SAKSBEHANDLE,
+                                authorizedAzps = listOf(AUTHORIZED_AZP)
+                            )
                         ) { _, dto ->
                             respond(dto)
                         }

--- a/plugin/src/test/kotlin/Fakes.kt
+++ b/plugin/src/test/kotlin/Fakes.kt
@@ -186,7 +186,7 @@ internal class AzureTokenGen(val issuer: String, val audience: String) {
         return signedJWT
     }
 
-    private fun claims(isApp: Boolean, roles: List<String>): JWTClaimsSet {
+    private fun claims(isApp: Boolean, roles: List<String>, azp: UUID? = null): JWTClaimsSet {
         val builder = JWTClaimsSet
             .Builder()
             .issuer(issuer)
@@ -195,6 +195,8 @@ internal class AzureTokenGen(val issuer: String, val audience: String) {
             .expirationTime(LocalDateTime.now().plusHours(4).toDate())
             .claim("NAVident", "Lokalsaksbehandler")
             .claim("azp_name", "azp")
+
+        azp?.let { builder.claim("azp", it.toString()) }
 
         if (isApp) {
             builder.claim("idtyp", "app")
@@ -211,8 +213,8 @@ internal class AzureTokenGen(val issuer: String, val audience: String) {
         return Date.from(this.atZone(ZoneId.systemDefault()).toInstant())
     }
 
-    fun generate(isApp: Boolean, roles: List<String> = emptyList()): String {
-        return signed(claims(isApp, roles)).serialize()
+    fun generate(isApp: Boolean, roles: List<String> = emptyList(), azp: UUID? = null): String {
+        return signed(claims(isApp, roles, azp)).serialize()
     }
 }
 

--- a/plugin/src/test/kotlin/TilgangPluginTest.kt
+++ b/plugin/src/test/kotlin/TilgangPluginTest.kt
@@ -607,13 +607,11 @@ class TilgangPluginTest {
     fun `token uten azp-claim gir ikke tilgang når authorizedAzps er satt via param-config`(isApp: Boolean) {
         val saksnummer = UUID.randomUUID()
         fakes.gittTilgangTilSak(saksnummer.toString(), true)
-        runBlocking {
-            // token uten azp-claim
-            val token = generateToken(isApp = isApp)
-            val res = httpClient.get(base("testApi/authorizedGet/$saksnummer/authorized-azps-param")) {
-                bearerAuth(token.token())
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = isApp, azp = null)
+                bearerGet<Saksinfo>(base("testApi/authorizedGet/$saksnummer/authorized-azps-param"), token.token())
             }
-            assertThat(res.status).isEqualTo(HttpStatusCode.Forbidden)
         }
     }
 
@@ -655,14 +653,15 @@ class TilgangPluginTest {
     fun `token uten azp-claim gir ikke tilgang når authorizedAzps er satt via body-config`(isApp: Boolean) {
         val saksnummer = UUID.randomUUID()
         fakes.gittTilgangTilSak(saksnummer.toString(), true)
-        runBlocking {
-            val token = generateToken(isApp = isApp)
-            val res = httpClient.post(base("testApi/authorizedPost/authorized-azps-body")) {
-                bearerAuth(token.token())
-                contentType(ContentType.Application.Json)
-                setBody(Saksinfo(saksnummer))
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = isApp, azp = null)
+                bearerPost<Saksinfo, Saksinfo>(
+                    base("testApi/authorizedPost/authorized-azps-body"),
+                    Saksinfo(saksnummer),
+                    token.token()
+                )
             }
-            assertThat(res.status).isEqualTo(HttpStatusCode.Forbidden)
         }
     }
 }

--- a/plugin/src/test/kotlin/TilgangPluginTest.kt
+++ b/plugin/src/test/kotlin/TilgangPluginTest.kt
@@ -38,7 +38,10 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.slf4j.LoggerFactory
+import kotlin.booleanArrayOf
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TilgangPluginTest {
@@ -46,8 +49,8 @@ class TilgangPluginTest {
         private val azureTokenGen = AzureTokenGen("behandlingsflyt", "behandlingsflyt")
         private val fakes = Fakes(azureTokenGen)
 
-        private fun generateToken(isApp: Boolean, roles: List<String> = emptyList()): OidcToken {
-            return OidcToken(azureTokenGen.generate(isApp, roles))
+        private fun generateToken(isApp: Boolean, roles: List<String> = emptyList(), azp: UUID? = null): OidcToken {
+            return OidcToken(azureTokenGen.generate(isApp, roles, azp))
         }
 
         data class Journalpostinfo(@param:PathParam("behandlingReferanse") val behandlingReferanse: String) :
@@ -96,7 +99,13 @@ class TilgangPluginTest {
     private suspend fun oboAccessToken(currentToken: OidcToken): String =
         httpClient.post(texasExchangeUrl) {
             contentType(ContentType.Application.Json)
-            setBody(mapOf("identity_provider" to "entra_id", "target" to "behandlingsflyt", "user_token" to currentToken.token()))
+            setBody(
+                mapOf(
+                    "identity_provider" to "entra_id",
+                    "target" to "behandlingsflyt",
+                    "user_token" to currentToken.token()
+                )
+            )
         }.body<Map<String, String>>()["access_token"]!!
 
     private suspend fun m2mAccessToken(): String =
@@ -150,7 +159,8 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         fakes.gittTilgangTilSak(randomUuid.toString(), true)
         runBlocking {
-            val res = oboGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/on-behalf-of"), generateToken(isApp = false))
+            val res =
+                oboGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/on-behalf-of"), generateToken(isApp = false))
             assertThat(res?.saksnummer).isEqualTo(randomUuid)
         }
     }
@@ -168,7 +178,8 @@ class TilgangPluginTest {
     fun `Skal gi tilgang basert på rolle for POST på samme route som GET`() {
         val token = generateToken(isApp = false, roles = listOf(Beslutter.id))
         runBlocking {
-            val res = bearerPost<IngenReferanse, IngenReferanse>(base("kun-roller"), IngenReferanse("input"), token.token())
+            val res =
+                bearerPost<IngenReferanse, IngenReferanse>(base("kun-roller"), IngenReferanse("input"), token.token())
             assertThat(res?.noe).isEqualTo("post-input")
         }
     }
@@ -205,7 +216,10 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("tilgang-rolle"))
         runBlocking {
-            val res = bearerGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/client-credentials-application-role"), token.token())
+            val res = bearerGet<Saksinfo>(
+                base("testApi/authorizedGet/$randomUuid/client-credentials-application-role"),
+                token.token()
+            )
             assertThat(res?.saksnummer).isEqualTo(randomUuid)
         }
     }
@@ -215,7 +229,12 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("feil-rolle"))
         assertThrows<ManglerTilgangException> {
-            runBlocking { bearerGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/client-credentials-application-role"), token.token()) }
+            runBlocking {
+                bearerGet<Saksinfo>(
+                    base("testApi/authorizedGet/$randomUuid/client-credentials-application-role"),
+                    token.token()
+                )
+            }
         }
     }
 
@@ -224,13 +243,21 @@ class TilgangPluginTest {
         val person = "234"
         fakes.gittTilgangTilPerson(person, true)
         runBlocking {
-            val res = oboPost<Personinfo, Personinfo>(base("testApi/person/post"), Personinfo(person), generateToken(isApp = false))
+            val res = oboPost<Personinfo, Personinfo>(
+                base("testApi/person/post"),
+                Personinfo(person),
+                generateToken(isApp = false)
+            )
             assertThat(res?.personIdent).isEqualTo("234")
         }
         val person2 = "123456"
         assertThrows<ManglerTilgangException> {
             runBlocking {
-                oboPost<Personinfo, Personinfo>(base("testApi/person/post"), Personinfo(person2), generateToken(isApp = false))
+                oboPost<Personinfo, Personinfo>(
+                    base("testApi/person/post"),
+                    Personinfo(person2),
+                    generateToken(isApp = false)
+                )
             }
         }
     }
@@ -262,9 +289,15 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         fakes.gittTilgangTilSak(randomUuid.toString(), true)
         runBlocking {
-            val res1 = oboGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/client-credentials-and-on-behalf-of"), generateToken(isApp = false))
+            val res1 = oboGet<Saksinfo>(
+                base("testApi/authorizedGet/$randomUuid/client-credentials-and-on-behalf-of"),
+                generateToken(isApp = false)
+            )
             val token = generateToken(isApp = true, roles = listOf("tilgang-rolle"))
-            val res2 = bearerGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/client-credentials-and-on-behalf-of"), token.token())
+            val res2 = bearerGet<Saksinfo>(
+                base("testApi/authorizedGet/$randomUuid/client-credentials-and-on-behalf-of"),
+                token.token()
+            )
             assertThat(res1?.saksnummer).isEqualTo(randomUuid)
             assertThat(res2?.saksnummer).isEqualTo(randomUuid)
         }
@@ -275,7 +308,11 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         fakes.gittTilgangTilSak(randomUuid.toString(), true)
         runBlocking {
-            val res = oboPost<Saksinfo, Saksinfo>(base("testApi/authorizedPost/on-behalf-of/saksinfo"), Saksinfo(randomUuid), generateToken(isApp = false))
+            val res = oboPost<Saksinfo, Saksinfo>(
+                base("testApi/authorizedPost/on-behalf-of/saksinfo"),
+                Saksinfo(randomUuid),
+                generateToken(isApp = false)
+            )
             assertThat(res?.saksnummer).isEqualTo(randomUuid)
         }
     }
@@ -287,7 +324,11 @@ class TilgangPluginTest {
         fakes.gittTilgangTilBehandling(behandlingReferanse, true)
         enAnnenReferanseTilbehandlingReferanse.put(enAnnenReferanse.toString(), behandlingReferanse)
         runBlocking {
-            val res = oboPost<Behandlinginfo, Behandlinginfo>(base("testApi/authorizedPost/on-behalf-of/behandlinginfo"), Behandlinginfo(enAnnenReferanse.toString()), generateToken(isApp = false))
+            val res = oboPost<Behandlinginfo, Behandlinginfo>(
+                base("testApi/authorizedPost/on-behalf-of/behandlinginfo"),
+                Behandlinginfo(enAnnenReferanse.toString()),
+                generateToken(isApp = false)
+            )
             assertThat(res?.enAnnenReferanse).isEqualTo(enAnnenReferanse.toString())
         }
     }
@@ -297,7 +338,11 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("tilgang-rolle"))
         runBlocking {
-            val res = bearerPost<IngenReferanse, IngenReferanse>(base("testApi/authorizedPost/client-credentials-application-role"), IngenReferanse(randomUuid.toString()), token.token())
+            val res = bearerPost<IngenReferanse, IngenReferanse>(
+                base("testApi/authorizedPost/client-credentials-application-role"),
+                IngenReferanse(randomUuid.toString()),
+                token.token()
+            )
             assertThat(res?.noe).isEqualTo(randomUuid.toString())
         }
     }
@@ -307,9 +352,17 @@ class TilgangPluginTest {
         val saksnummer = UUID.randomUUID()
         fakes.gittTilgangTilSak(saksnummer.toString(), true)
         runBlocking {
-            val res1 = oboPost<Saksinfo, Saksinfo>(base("testApi/authorizedPost/client-credentials-and-on-behalf-of"), Saksinfo(saksnummer), generateToken(isApp = false))
+            val res1 = oboPost<Saksinfo, Saksinfo>(
+                base("testApi/authorizedPost/client-credentials-and-on-behalf-of"),
+                Saksinfo(saksnummer),
+                generateToken(isApp = false)
+            )
             val token = generateToken(isApp = true, roles = listOf("tilgang-rolle"))
-            val res2 = bearerPost<Saksinfo, Saksinfo>(base("testApi/authorizedPost/client-credentials-and-on-behalf-of"), Saksinfo(saksnummer), token.token())
+            val res2 = bearerPost<Saksinfo, Saksinfo>(
+                base("testApi/authorizedPost/client-credentials-and-on-behalf-of"),
+                Saksinfo(saksnummer),
+                token.token()
+            )
             assertThat(res1?.saksnummer).isEqualTo(saksnummer)
             assertThat(res2?.saksnummer).isEqualTo(saksnummer)
         }
@@ -320,7 +373,11 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("tilgang-rolle"))
         runBlocking {
-            val res = bearerPost<IngenReferanse, IngenReferanse>(base("testApi/authorizedPost/client-credentials-application-role"), IngenReferanse(randomUuid.toString()), token.token())
+            val res = bearerPost<IngenReferanse, IngenReferanse>(
+                base("testApi/authorizedPost/client-credentials-application-role"),
+                IngenReferanse(randomUuid.toString()),
+                token.token()
+            )
             assertThat(res?.noe).isEqualTo(randomUuid.toString())
         }
     }
@@ -330,7 +387,13 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("feil-rolle"))
         assertThrows<ManglerTilgangException> {
-            runBlocking { bearerPost<IngenReferanse, IngenReferanse>(base("testApi/authorizedPost/client-credentials-application-role"), IngenReferanse(randomUuid.toString()), token.token()) }
+            runBlocking {
+                bearerPost<IngenReferanse, IngenReferanse>(
+                    base("testApi/authorizedPost/client-credentials-application-role"),
+                    IngenReferanse(randomUuid.toString()),
+                    token.token()
+                )
+            }
         }
     }
 
@@ -340,7 +403,11 @@ class TilgangPluginTest {
         val journalpostId = 456L
         fakes.gittTilgangTilJournalpost(journalpostId, true)
         runBlocking {
-            val res = oboPost<IngenReferanse, IngenReferanse>(base("testApi/pathForPost/resolve/journalpost/$behandlingsRef"), IngenReferanse("test"), generateToken(isApp = false))
+            val res = oboPost<IngenReferanse, IngenReferanse>(
+                base("testApi/pathForPost/resolve/journalpost/$behandlingsRef"),
+                IngenReferanse("test"),
+                generateToken(isApp = false)
+            )
             assertThat(res?.noe).isEqualTo("test")
         }
     }
@@ -352,51 +419,66 @@ class TilgangPluginTest {
         fakes.gittTilgangTilBehandling(behandlingReferanse, true)
         enAnnenReferanseTilbehandlingReferanse.put(enAnnenReferanse.toString(), behandlingReferanse)
         runBlocking {
-            val res = oboPost<IngenReferanse, IngenReferanse>(base("testApi/pathForPost/resolve/behandlingreferanse/$enAnnenReferanse"), IngenReferanse("test"), generateToken(isApp = false))
+            val res = oboPost<IngenReferanse, IngenReferanse>(
+                base("testApi/pathForPost/resolve/behandlingreferanse/$enAnnenReferanse"),
+                IngenReferanse("test"),
+                generateToken(isApp = false)
+            )
             assertThat(res?.noe).isEqualTo("test")
         }
     }
 
     @Test
-    fun `skal auditlogge - path resolver`() = runBlocking {
-        val randomUuid = UUID.randomUUID()
-        fakes.gittTilgangTilSak(randomUuid.toString(), true)
+    fun `skal auditlogge - path resolver`() {
+        runBlocking {
+            val randomUuid = UUID.randomUUID()
+            fakes.gittTilgangTilSak(randomUuid.toString(), true)
 
-        val logger = LoggerFactory.getLogger(TILGANG_PLUGIN) as Logger
-        val appender = LogCaptureAppender()
-        appender.start()
-        logger.addAppender(appender)
+            val logger = LoggerFactory.getLogger(TILGANG_PLUGIN) as Logger
+            val appender = LogCaptureAppender()
+            appender.start()
+            logger.addAppender(appender)
 
-        val res = oboGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/on-behalf-of"), generateToken(isApp = false))
-        assertThat(res?.saksnummer).isEqualTo(randomUuid)
+            val res =
+                oboGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/on-behalf-of"), generateToken(isApp = false))
+            assertThat(res?.saksnummer).isEqualTo(randomUuid)
 
-        val messages = appender.getLoggedMessages()
-        val expected = messages.first { it.contains("CEF:0|Kelvin|behandlingsflyt|1.0|audit:access|Auditlogg|INFO|flexString1=Permit request=/testApi/authorizedGet/$randomUuid/on-behalf-of duid=12345678901 flexString1Label=Decision end=") }
-        assertNotNull(expected)
-        assertTrue(expected.contains("suid=Lokalsaksbehandler"))
+            val messages = appender.getLoggedMessages()
+            val expected =
+                messages.first { it.contains("CEF:0|Kelvin|behandlingsflyt|1.0|audit:access|Auditlogg|INFO|flexString1=Permit request=/testApi/authorizedGet/$randomUuid/on-behalf-of duid=12345678901 flexString1Label=Decision end=") }
+            assertNotNull(expected)
+            assertTrue(expected.contains("suid=Lokalsaksbehandler"))
 
-        logger.detachAppender(appender)
+            logger.detachAppender(appender)
+        }
     }
 
     @Test
-    fun `skal auditlogge - body resolver`() = runBlocking {
-        val randomUuid = UUID.randomUUID()
-        fakes.gittTilgangTilSak(randomUuid.toString(), true)
+    fun `skal auditlogge - body resolver`() {
+        runBlocking {
+            val randomUuid = UUID.randomUUID()
+            fakes.gittTilgangTilSak(randomUuid.toString(), true)
 
-        val logger = LoggerFactory.getLogger(TILGANG_PLUGIN) as Logger
-        val appender = LogCaptureAppender()
-        appender.start()
-        logger.addAppender(appender)
+            val logger = LoggerFactory.getLogger(TILGANG_PLUGIN) as Logger
+            val appender = LogCaptureAppender()
+            appender.start()
+            logger.addAppender(appender)
 
-        val res = oboPost<RequestMedAuditResolver, RequestMedAuditResolver>(base("testApi/authorizedPost/med-audit-resolver"), RequestMedAuditResolver(saksreferanse = randomUuid), generateToken(isApp = false))
-        assertThat(res?.saksreferanse).isEqualTo(randomUuid)
+            val res = oboPost<RequestMedAuditResolver, RequestMedAuditResolver>(
+                base("testApi/authorizedPost/med-audit-resolver"),
+                RequestMedAuditResolver(saksreferanse = randomUuid),
+                generateToken(isApp = false)
+            )
+            assertThat(res?.saksreferanse).isEqualTo(randomUuid)
 
-        val messages = appender.getLoggedMessages()
-        val expected = messages.first { it.contains("CEF:0|Kelvin|behandlingsflyt|1.0|audit:access|Auditlogg|INFO|flexString1=Permit request=/testApi/authorizedPost/med-audit-resolver duid=12345678901 flexString1Label=Decision end=") }
-        assertNotNull(expected)
-        assertTrue(expected.contains("suid=Lokalsaksbehandler"))
+            val messages = appender.getLoggedMessages()
+            val expected =
+                messages.first { it.contains("CEF:0|Kelvin|behandlingsflyt|1.0|audit:access|Auditlogg|INFO|flexString1=Permit request=/testApi/authorizedPost/med-audit-resolver duid=12345678901 flexString1Label=Decision end=") }
+            assertNotNull(expected)
+            assertTrue(expected.contains("suid=Lokalsaksbehandler"))
 
-        logger.detachAppender(appender)
+            logger.detachAppender(appender)
+        }
     }
 
     @Test
@@ -404,7 +486,10 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("tilgang-rolle"))
         runBlocking {
-            val res = bearerGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/application-role-machine-to-machine"), token.token())
+            val res = bearerGet<Saksinfo>(
+                base("testApi/authorizedGet/$randomUuid/application-role-machine-to-machine"),
+                token.token()
+            )
             assertThat(res?.saksnummer).isEqualTo(randomUuid)
         }
     }
@@ -414,7 +499,12 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         val token = generateToken(isApp = true, roles = listOf("feil-rolle"))
         assertThrows<ManglerTilgangException> {
-            runBlocking { bearerGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/application-role-machine-to-machine"), token.token()) }
+            runBlocking {
+                bearerGet<Saksinfo>(
+                    base("testApi/authorizedGet/$randomUuid/application-role-machine-to-machine"),
+                    token.token()
+                )
+            }
         }
     }
 
@@ -433,7 +523,12 @@ class TilgangPluginTest {
     fun `get sak med påkrevdRolle gir ikke tilgang`() {
         val randomUuid = UUID.randomUUID()
         assertThrows<ManglerTilgangException> {
-            runBlocking { oboGet<Saksinfo>(base("testApi/paakrevdRolle/sak/$randomUuid"), generateToken(isApp = false)) }
+            runBlocking {
+                oboGet<Saksinfo>(
+                    base("testApi/paakrevdRolle/sak/$randomUuid"),
+                    generateToken(isApp = false)
+                )
+            }
         }
     }
 
@@ -442,7 +537,11 @@ class TilgangPluginTest {
         val randomUuid = UUID.randomUUID()
         fakes.gittTilgangTilSak(randomUuid.toString(), true)
         runBlocking {
-            val res = oboPost<Saksinfo, Saksinfo>(base("testApi/paakrevdRolle/sak/post"), Saksinfo(randomUuid), generateToken(isApp = false))
+            val res = oboPost<Saksinfo, Saksinfo>(
+                base("testApi/paakrevdRolle/sak/post"),
+                Saksinfo(randomUuid),
+                generateToken(isApp = false)
+            )
             assertThat(res?.saksnummer).isEqualTo(randomUuid)
             assertThat(fakes.sistMottattSakTilgangRequest?.påkrevdRolle).isEqualTo(listOf(Rolle.BESLUTTER))
         }
@@ -452,7 +551,13 @@ class TilgangPluginTest {
     fun `post sak med påkrevdRolle gir ikke tilgang`() {
         val randomUuid = UUID.randomUUID()
         assertThrows<ManglerTilgangException> {
-            runBlocking { oboPost<Saksinfo, Saksinfo>(base("testApi/paakrevdRolle/sak/post"), Saksinfo(randomUuid), generateToken(isApp = false)) }
+            runBlocking {
+                oboPost<Saksinfo, Saksinfo>(
+                    base("testApi/paakrevdRolle/sak/post"),
+                    Saksinfo(randomUuid),
+                    generateToken(isApp = false)
+                )
+            }
         }
     }
 
@@ -460,10 +565,105 @@ class TilgangPluginTest {
     fun `skal returnere json ved ikke tilgang`() {
         val randomUuid = UUID.randomUUID()
         assertThatThrownBy {
-            runBlocking { oboGet<Saksinfo>(base("testApi/authorizedGet/$randomUuid/on-behalf-of"), generateToken(isApp = false)) }
+            runBlocking {
+                oboGet<Saksinfo>(
+                    base("testApi/authorizedGet/$randomUuid/on-behalf-of"),
+                    generateToken(isApp = false)
+                )
+            }
         }.isInstanceOf(ManglerTilgangException::class.java)
             .extracting("body")
             .isEqualTo("{\"message\":\"Ingen tilgang\",\"code\":\"UKJENT_FEIL\"}")
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `token med autorisert azp gir tilgang via param-config`(isApp: Boolean) {
+        val saksnummer = UUID.randomUUID()
+        fakes.gittTilgangTilSak(saksnummer.toString(), true)
+        runBlocking {
+            val token = generateToken(isApp = isApp, azp = AUTHORIZED_AZP)
+            val res =
+                bearerGet<Saksinfo>(base("testApi/authorizedGet/$saksnummer/authorized-azps-param"), token.token())
+            assertThat(res?.saksnummer).isEqualTo(saksnummer)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `token med ikke-autorisert azp gir ikke tilgang via param-config`(isApp: Boolean) {
+        val saksnummer = UUID.randomUUID()
+        fakes.gittTilgangTilSak(saksnummer.toString(), true)
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = isApp, azp = UUID.randomUUID())
+                bearerGet<Saksinfo>(base("testApi/authorizedGet/$saksnummer/authorized-azps-param"), token.token())
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `token uten azp-claim gir ikke tilgang når authorizedAzps er satt via param-config`(isApp: Boolean) {
+        val saksnummer = UUID.randomUUID()
+        fakes.gittTilgangTilSak(saksnummer.toString(), true)
+        runBlocking {
+            // token uten azp-claim
+            val token = generateToken(isApp = isApp)
+            val res = httpClient.get(base("testApi/authorizedGet/$saksnummer/authorized-azps-param")) {
+                bearerAuth(token.token())
+            }
+            assertThat(res.status).isEqualTo(HttpStatusCode.Forbidden)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `token med autorisert azp gir tilgang via body-config`(isApp: Boolean) {
+        val saksnummer = UUID.randomUUID()
+        fakes.gittTilgangTilSak(saksnummer.toString(), true)
+        runBlocking {
+            val token = generateToken(isApp = isApp, azp = AUTHORIZED_AZP)
+            val res = bearerPost<Saksinfo, Saksinfo>(
+                base("testApi/authorizedPost/authorized-azps-body"),
+                Saksinfo(saksnummer),
+                token.token()
+            )
+            assertThat(res?.saksnummer).isEqualTo(saksnummer)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `token med ikke-autorisert azp gir ikke tilgang via body-config`(isApp: Boolean) {
+        val saksnummer = UUID.randomUUID()
+        fakes.gittTilgangTilSak(saksnummer.toString(), true)
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = isApp, azp = UUID.randomUUID())
+                bearerPost<Saksinfo, Saksinfo>(
+                    base("testApi/authorizedPost/authorized-azps-body"),
+                    Saksinfo(saksnummer),
+                    token.token()
+                )
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `token uten azp-claim gir ikke tilgang når authorizedAzps er satt via body-config`(isApp: Boolean) {
+        val saksnummer = UUID.randomUUID()
+        fakes.gittTilgangTilSak(saksnummer.toString(), true)
+        runBlocking {
+            val token = generateToken(isApp = isApp)
+            val res = httpClient.post(base("testApi/authorizedPost/authorized-azps-body")) {
+                bearerAuth(token.token())
+                contentType(ContentType.Application.Json)
+                setBody(Saksinfo(saksnummer))
+            }
+            assertThat(res.status).isEqualTo(HttpStatusCode.Forbidden)
+        }
     }
 }
 


### PR DESCRIPTION
Mulighet for å autorisere azp, dvs. hvilken app som spør. Relevant både for obo- og m2m-token:
- Kan begrense hvilken app som kan kalle et endepunkt på vegne av innlogget bruker med obo-token
- For m2m er autorisering med azp et alternativ til autorisering basert på roles-claim