### PR TITLE
AAP-2194 Sikrer at token er m2m-token for m2m-plugin

### DIFF
--- a/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
+++ b/plugin/src/main/kotlin/no/nav/aap/tilgang/TilgangPlugin.kt
@@ -115,10 +115,19 @@ fun Route.installerTilgangMachineToMachinePlugin(
         on(AuthenticationChecked) { call ->
             if (call.request.httpMethod != httpMethod) return@on
             val principal = call.principal<JWTPrincipal>() ?: error("mangler principal")
-
+            if (!call.token().isClientCredentials()) {
+                call.respondWithError(IkkeTillattException("Ingen tilgang"))
+                return@on
+            }
             if (config.authorizedAzps.isNotEmpty()) {
                 val azpName = principal.getClaim("azp_name", String::class)
-                val azp = principal.getClaim("azp", UUID::class) ?: error("token uten azp-claim")
+                val azp = principal.getClaim("azp", UUID::class)
+
+                if (azp == null) {
+                    log.error("token uten azp-claim")
+                    call.respondWithError(IkkeTillattException("Ingen tilgang"))
+                    return@on
+                }
 
                 if (azp in config.authorizedAzps) {
                     return@on

--- a/plugin/src/test/kotlin/AutorisertEksempelApp.kt
+++ b/plugin/src/test/kotlin/AutorisertEksempelApp.kt
@@ -222,6 +222,15 @@ fun Application.autorisertEksempelApp() {
                             respond(Saksinfo(saksnummer = req.saksnummer))
                         }
                     }
+                    route("authorized-azps-machine-to-machine") {
+                        authorizedGet<TestReferanse, Saksinfo>(
+                            AuthorizationMachineToMachineConfig(
+                                authorizedAzps = listOf(AUTHORIZED_AZP)
+                            )
+                        ) { req ->
+                            respond(Saksinfo(saksnummer = req.saksnummer))
+                        }
+                    }
                     route("client-credentials-and-on-behalf-of") {
                         authorizedGet<TestReferanse, Saksinfo>(
                             AuthorizationParamPathConfig(

--- a/plugin/src/test/kotlin/TilgangPluginTest.kt
+++ b/plugin/src/test/kotlin/TilgangPluginTest.kt
@@ -664,6 +664,62 @@ class TilgangPluginTest {
             }
         }
     }
+
+    @Test
+    fun `maskin-til-maskin token med autorisert azp gir tilgang`() {
+        val saksnummer = UUID.randomUUID()
+        runBlocking {
+            val token = generateToken(isApp = true, azp = AUTHORIZED_AZP)
+            val res = bearerGet<Saksinfo>(
+                base("testApi/authorizedGet/$saksnummer/authorized-azps-machine-to-machine"),
+                token.token()
+            )
+            assertThat(res?.saksnummer).isEqualTo(saksnummer)
+        }
+    }
+
+    @Test
+    fun `maskin-til-maskin token med ikke-autorisert azp gir ikke tilgang`() {
+        val saksnummer = UUID.randomUUID()
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = true, azp = UUID.randomUUID())
+                bearerGet<Saksinfo>(
+                    base("testApi/authorizedGet/$saksnummer/authorized-azps-machine-to-machine"),
+                    token.token()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `maskin-til-maskin token uten azp gir ikke tilgang`() {
+        val saksnummer = UUID.randomUUID()
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = true, azp = null)
+                bearerGet<Saksinfo>(
+                    base("testApi/authorizedGet/$saksnummer/authorized-azps-machine-to-machine"),
+                    token.token()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `obo token med autorisert azp gir ikke tilgang`() {
+        val saksnummer = UUID.randomUUID()
+        assertThrows<ManglerTilgangException> {
+            runBlocking {
+                val token = generateToken(isApp = false, azp = AUTHORIZED_AZP)
+                val res = bearerGet<Saksinfo>(
+                    base("testApi/authorizedGet/$saksnummer/authorized-azps-machine-to-machine"),
+                    token.token()
+                )
+                assertThat(res?.saksnummer).isEqualTo(saksnummer)
+            }
+        }
+    }
 }
 
 class LogCaptureAppender : AppenderBase<ILoggingEvent>() {


### PR DESCRIPTION
Returnerer også 403 ved manglende azp-claim