### PR TITLE
AAP-2194 Forenkle tilgang til person for rolle DRIFT

### DIFF
--- a/app/main/kotlin/tilgang/TilgangService.kt
+++ b/app/main/kotlin/tilgang/TilgangService.kt
@@ -17,6 +17,7 @@ import tilgang.integrasjoner.saf.SafGraphqlGateway
 import tilgang.integrasjoner.saf.SafJournalpost
 import tilgang.integrasjoner.tilgangsmaskin.BrukerOgRegeltype
 import tilgang.integrasjoner.tilgangsmaskin.TilgangsmaskinGateway
+import tilgang.regler.DriftRolleRegel
 import tilgang.regler.RegelInput
 import tilgang.regler.RegelService
 
@@ -140,10 +141,31 @@ class TilgangService(
         return tilgangsmaskinGateway.harTilganger(brukerIdenter, token)
     }
 
-    suspend fun harTilgangTilPerson(brukerIdent: String, token: OidcToken): Boolean {
+    suspend fun harTilgangTilPerson(
+        ansattIdent: String,
+        brukerIdent: String,
+        token: OidcToken,
+        roller: List<Rolle>,
+        callId: String
+    ): Boolean {
+        if (Rolle.DRIFT in roller) {
+            val regelInput = RegelInput(
+                callId = callId,
+                ansattIdent = ansattIdent,
+                currentToken = token,
+                roller = roller,
+                søkerIdenter = RelevanteIdenter(listOf(brukerIdent), emptyList()),
+                avklaringsbehovFraBehandlingsflyt = null,
+                avklaringsbehovFraPostmottak = null,
+                påkrevdRolle = listOf(Rolle.DRIFT),
+                operasjoner = listOf(Operasjon.DRIFTE),
+            )
+
+            return regelService.vurderTilgang(regelInput)[Operasjon.DRIFTE] == true
+        }
+
         return tilgangsmaskinGateway.harTilgangTilPerson(brukerIdent, token)
     }
-
 
     suspend fun harTilgangTilTilbakekreving(
         ansattIdent: String,

--- a/app/main/kotlin/tilgang/routes/TilgangRoute.kt
+++ b/app/main/kotlin/tilgang/routes/TilgangRoute.kt
@@ -106,7 +106,11 @@ fun NormalOpenAPIRoute.tilgang(
         route("/person") {
             post<Unit, TilgangResponse, PersonTilgangRequest> { _, req ->
                 prometheus.httpCallCounter(pipeline.call).increment()
-                val harTilgang = tilgangService.harTilgangTilPerson(req.personIdent, token())
+
+                val callId = pipeline.call.request.header("Nav-CallId") ?: "ukjent"
+                val roller = parseRoller(rolesWithGroupIds = roles, roller())
+
+                val harTilgang = tilgangService.harTilgangTilPerson(ident(), req.personIdent, token(), roller, callId)
                 respond(TilgangResponse(harTilgang))
             }
         }


### PR DESCRIPTION
`harTilgangTilPerson` går mot endepunktet `/komplett` i tilgangsmaskinen. Utviklere med rolle drift vil aldri få tilgang mot denne. 

`RegelService.vurderTilgang` med `Rolle.DRIFT` går mot endepunktet `/kjerne` som er mer enn dekkende nok for driftsbehovet. 