### PR TITLE
AAP-2328 Ta i bruk komplett-endepunkt fra tilgangsmaskinen i dev

### DIFF
--- a/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinGateway.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinGateway.kt
@@ -1,10 +1,14 @@
 package tilgang.integrasjoner.tilgangsmaskin
 
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.plugins.*
-import io.ktor.client.request.*
-import io.ktor.http.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.micrometer.core.instrument.MeterRegistry
 import no.nav.aap.komponenter.config.requiredConfigForKey
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken

--- a/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinGateway.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinGateway.kt
@@ -1,21 +1,16 @@
 package tilgang.integrasjoner.tilgangsmaskin
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.request.bearerAuth
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 import io.micrometer.core.instrument.MeterRegistry
 import no.nav.aap.komponenter.config.requiredConfigForKey
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
 import org.slf4j.LoggerFactory
 import tilgang.auth.ITokenProvider
 import tilgang.auth.TokenProvider
-
 import tilgang.metrics.cacheHit
 import tilgang.metrics.cacheMiss
 import tilgang.redis.Key
@@ -31,9 +26,16 @@ interface ITilgangsmaskinGateway {
         token: OidcToken,
         ansattIdent: String,
     ): HarTilgangFraTilgangsmaskinen
+
+    suspend fun harTilgangTilPersonKomplett(
+        brukerIdent: String,
+        token: OidcToken,
+        ansattIdent: String
+    ): HarTilgangFraTilgangsmaskinen
 }
 
 private val log = LoggerFactory.getLogger(TilgangsmaskinGateway::class.java)
+private val redisExpireSec = 21600L
 
 /**
  * Se Confluence for dokumentasjon.
@@ -82,7 +84,7 @@ class TilgangsmaskinGateway(
                 setBody(brukerIdent)
             }
             val tilgang = HarTilgangFraTilgangsmaskinen(true)
-            redis.set(Key(TILGANGSMASKIN_KJERNE_PREFIX, brukerIdent + ansattIdent), tilgang.serialize(), 21600)
+            redis.set(Key(TILGANGSMASKIN_KJERNE_PREFIX, brukerIdent + ansattIdent), tilgang.serialize(), redisExpireSec)
             tilgang
         } catch (e: ClientRequestException) {
             if (e.response.status == HttpStatusCode.Forbidden) {
@@ -93,7 +95,54 @@ class TilgangsmaskinGateway(
                 }.getOrNull()
                 avvistResponse?.let { log.info("403 fra tilgangsmaskin: ${it.title}") }
                 val ikkeTilgang = HarTilgangFraTilgangsmaskinen(false, avvistResponse)
-                redis.set(Key(TILGANGSMASKIN_KJERNE_PREFIX, brukerIdent + ansattIdent), ikkeTilgang.serialize(), 21600)
+                redis.set(
+                    Key(TILGANGSMASKIN_KJERNE_PREFIX, brukerIdent + ansattIdent),
+                    ikkeTilgang.serialize(),
+                    redisExpireSec
+                )
+                ikkeTilgang
+            } else throw e
+        }
+    }
+
+    override suspend fun harTilgangTilPersonKomplett(
+        brukerIdent: String,
+        token: OidcToken,
+        ansattIdent: String
+    ): HarTilgangFraTilgangsmaskinen {
+        redis[Key(TILGANGSMASKIN_KOMPLETT_PREFIX, brukerIdent + ansattIdent)]?.let {
+            prometheus.cacheHit(TILGANGSMASKIN_KOMPLETT_PREFIX).increment()
+            return it.deserialize()
+        }
+        prometheus.cacheMiss(TILGANGSMASKIN_KOMPLETT_PREFIX).increment()
+
+        return try {
+            httpClient.post("$baseUrl/api/v1/komplett") {
+                bearerAuth(tokenProvider.oboToken(scope, token))
+                contentType(ContentType.Application.Json)
+                setBody(brukerIdent)
+            }
+            val tilgang = HarTilgangFraTilgangsmaskinen(true)
+            redis.set(
+                Key(TILGANGSMASKIN_KOMPLETT_PREFIX, brukerIdent + ansattIdent),
+                tilgang.serialize(),
+                redisExpireSec
+            )
+            tilgang
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.Forbidden) {
+                val avvistResponse = runCatching {
+                    e.response.body<TilgangsmaskinAvvistResponse>()
+                }.onFailure { parseErr ->
+                    log.warn("Greide ikke parse avvist-respons fra tilgangsmaskinen", parseErr)
+                }.getOrNull()
+                avvistResponse?.let { log.info("403 fra tilgangsmaskin: ${it.title}") }
+                val ikkeTilgang = HarTilgangFraTilgangsmaskinen(false, avvistResponse)
+                redis.set(
+                    Key(TILGANGSMASKIN_KOMPLETT_PREFIX, brukerIdent + ansattIdent),
+                    ikkeTilgang.serialize(),
+                    redisExpireSec
+                )
                 ikkeTilgang
             } else throw e
         }
@@ -117,5 +166,6 @@ class TilgangsmaskinGateway(
 
     companion object {
         private const val TILGANGSMASKIN_KJERNE_PREFIX = "tilgangsmaskinKjerne"
+        private const val TILGANGSMASKIN_KOMPLETT_PREFIX = "tilgangsmaskinKomplett"
     }
 }

--- a/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinModell.kt
+++ b/app/main/kotlin/tilgang/integrasjoner/tilgangsmaskin/TilgangsmaskinModell.kt
@@ -12,7 +12,9 @@ enum class TilgangsmaskinAvvistGrunn{
     AVVIST_FORTROLIG_ADRESSE,
     AVVIST_SKJERMING,
     AVVIST_VERGE,
-    AVVIST_MANGLENDE_DATA
+    AVVIST_MANGLENDE_DATA,
+    AVVIST_GEOGRAFISK,
+    AVVIST_AVDØD
 }
 
 data class TilgangsmaskinAvvistResponse(

--- a/app/main/kotlin/tilgang/regler/Regler.kt
+++ b/app/main/kotlin/tilgang/regler/Regler.kt
@@ -1,5 +1,6 @@
 package tilgang.regler
 
+import no.nav.aap.komponenter.miljo.Miljø
 import no.nav.aap.tilgang.Operasjon
 import tilgang.integrasjoner.pdl.IPdlGraphQLGateway
 import tilgang.integrasjoner.skjerming.SkjermingGateway
@@ -17,7 +18,27 @@ class RegelService(
     tilgangsmaskinGateway: TilgangsmaskinGateway
 ) {
 
-    private val regelOpppsett = mapOf(
+    private val regelOppsettMedTilgangsmaskinKomplett = mapOf(
+        Operasjon.SE to listOf(
+            LeseRolleRegel,
+            AdressebeskyttelseRegel,
+            TilgangsmaskinKomplettRegel
+        ),
+        Operasjon.DRIFTE to listOf(
+            DriftRolleRegel,
+            TilgangsmaskinKjerneRegel,
+        ),
+        Operasjon.DELEGERE to listOf(
+            AvdelingslederRolleRegel,
+        ),
+        Operasjon.SAKSBEHANDLE to listOf(
+            AvklaringsbehovRolleRegel,
+            AdressebeskyttelseRegel,
+            TilgangsmaskinKomplettRegel
+        )
+    )
+
+    private val regelOppsettUtenTilgangsmaskinKomplett = mapOf(
         Operasjon.SE to listOf(
             LeseRolleRegel,
             TilgangsmaskinKjerneRegel,
@@ -49,10 +70,19 @@ class RegelService(
         DriftRolleRegel to RegelMedInputgenerator(DriftRolleRegel, RolleInputGenerator),
         AvdelingslederRolleRegel to RegelMedInputgenerator(AvdelingslederRolleRegel, RolleInputGenerator),
         AvklaringsbehovRolleRegel to RegelMedInputgenerator(AvklaringsbehovRolleRegel, AvklaringsbehovInputGenerator),
+        TilgangsmaskinKomplettRegel to RegelMedInputgenerator(
+            TilgangsmaskinKomplettRegel,
+            TilgangsmaskinKomplettInputGenerator(tilgangsmaskinGateway)
+        )
     )
 
     suspend fun vurderTilgang(input: RegelInput): Map<Operasjon, Boolean> {
-        val aktuelleOperasjoner = regelOpppsett.filterKeys { it in input.operasjoner }
+        val aktuelleOperasjoner = if (Miljø.erProd()) {
+            regelOppsettUtenTilgangsmaskinKomplett.filterKeys { it in input.operasjoner }
+        } else {
+            regelOppsettMedTilgangsmaskinKomplett.filterKeys { it in input.operasjoner }
+        }
+
         val regelCache = mutableMapOf<Regel<*>, Boolean>()
 
         return aktuelleOperasjoner.mapValues { (_, regler) ->

--- a/app/main/kotlin/tilgang/regler/TilgangsmaskinKomplettRegel.kt
+++ b/app/main/kotlin/tilgang/regler/TilgangsmaskinKomplettRegel.kt
@@ -1,0 +1,21 @@
+package tilgang.regler
+
+import tilgang.integrasjoner.tilgangsmaskin.HarTilgangFraTilgangsmaskinen
+import tilgang.integrasjoner.tilgangsmaskin.ITilgangsmaskinGateway
+
+data object TilgangsmaskinKomplettRegel : Regel<TilgangsmaskinKomplettInput> {
+    override fun vurder(input: TilgangsmaskinKomplettInput): Boolean {
+        return input.tilgangsmaskinResponse.harTilgang
+    }
+}
+
+class TilgangsmaskinKomplettInputGenerator(private val tilgangsmaskinGateway: ITilgangsmaskinGateway) :
+    InputGenerator<TilgangsmaskinKomplettInput> {
+    override suspend fun generer(input: RegelInput): TilgangsmaskinKomplettInput {
+        val tilgangsmaskinResponse =
+            tilgangsmaskinGateway.harTilgangTilPersonKomplett(input.søkerIdenter.søker.first(), input.currentToken, input.ansattIdent)
+        return TilgangsmaskinKomplettInput(tilgangsmaskinResponse)
+    }
+}
+
+data class TilgangsmaskinKomplettInput(val tilgangsmaskinResponse: HarTilgangFraTilgangsmaskinen)

--- a/app/test/kotlin/tilgang/fakes/TilgangsmaskinFake.kt
+++ b/app/test/kotlin/tilgang/fakes/TilgangsmaskinFake.kt
@@ -46,10 +46,10 @@ fun Application.tilgangsmaskinFake() {
             if (body.contains("456")) {
                 val body = TilgangsmaskinAvvistResponse(
                     type = "https://confluence.adeo.no/display/TM/Tilgangsmaskin+API+og+regelsett",
-                    title = "AVVIST_HABILITET",
+                    title = "AVVIST_GEOGRAFISK",
                     status = 403,
                     navIdent = "Z990883",
-                    begrunnelse = "Inhabil",
+                    begrunnelse = "Du har ikke tilgang til brukerens geografiske område eller enhet.",
                     kanOverstyres = false
                 )
                 call.respond(HttpStatusCode.Forbidden, body)

--- a/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
@@ -28,4 +28,16 @@ class TilgangsmaskinTest {
         assertFalse(harIkkeTilgangResponse.harTilgang)
         assertTrue(harIkkeTilgangResponse.tilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString())
     }
+
+    @Test
+    fun `Kan parse harTilgangTilPersonKomplett`() = runTest {
+        val token = AzureTokenGen("tilgangazure", "tilgang").generate()
+        val tilgangsmaskinGateway = TilgangsmaskinGateway(redis, httpClient, prometheus)
+        val harTilgangResponse = tilgangsmaskinGateway.harTilgangTilPersonKomplett("123", OidcToken(token), "799")
+        val harIkkeTilgangResponse = tilgangsmaskinGateway.harTilgangTilPersonKomplett("456", OidcToken(token), "799")
+
+        assertTrue(harTilgangResponse.harTilgang)
+        assertFalse(harIkkeTilgangResponse.harTilgang)
+        assertTrue(harIkkeTilgangResponse.tilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_GEOGRAFISK.toString())
+    }
 }

--- a/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
+++ b/app/test/kotlin/tilgang/integrasjoner/TilgangsmaskinTest.kt
@@ -2,8 +2,7 @@ package tilgang.integrasjoner
 
 import kotlinx.coroutines.test.runTest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import tilgang.AzureTokenGen
 import tilgang.fakes.Fakes
@@ -24,9 +23,9 @@ class TilgangsmaskinTest {
         val harTilgangResponse = tilgangsmaskinGateway.harTilgangTilPersonKjerne("123", OidcToken(token), "799")
         val harIkkeTilgangResponse = tilgangsmaskinGateway.harTilgangTilPersonKjerne("456", OidcToken(token), "799")
 
-        assertTrue(harTilgangResponse.harTilgang)
-        assertFalse(harIkkeTilgangResponse.harTilgang)
-        assertTrue(harIkkeTilgangResponse.tilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString())
+        assertThat(harTilgangResponse.harTilgang).isTrue()
+        assertThat(harIkkeTilgangResponse.harTilgang).isFalse()
+        assertThat(harIkkeTilgangResponse.tilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_HABILITET.toString()).isTrue()
     }
 
     @Test
@@ -36,8 +35,8 @@ class TilgangsmaskinTest {
         val harTilgangResponse = tilgangsmaskinGateway.harTilgangTilPersonKomplett("123", OidcToken(token), "799")
         val harIkkeTilgangResponse = tilgangsmaskinGateway.harTilgangTilPersonKomplett("456", OidcToken(token), "799")
 
-        assertTrue(harTilgangResponse.harTilgang)
-        assertFalse(harIkkeTilgangResponse.harTilgang)
-        assertTrue(harIkkeTilgangResponse.tilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_GEOGRAFISK.toString())
+        assertThat(harTilgangResponse.harTilgang).isTrue()
+        assertThat(harIkkeTilgangResponse.harTilgang).isFalse()
+        assertThat(harIkkeTilgangResponse.tilgangsmaskinAvvistResponse?.title == TilgangsmaskinAvvistGrunn.AVVIST_GEOGRAFISK.toString()).isTrue()
     }
 }


### PR DESCRIPTION
Legger til ny TilgangsmaskinKomplettRegel som erstatter dagens TilgangsmaskinKjerneRegel (i praksis EgenSakRegel), GeoRegel og EgenAnsattRegel. Vi må fortsatt ha AvklaringsbehovRolleRegel og AdressbeskyttelseRegel, siden vi sjekker adressebeskyttelse på alle relevante identer på sak.

Denne PR-en skrur bare på ny regel i dev.